### PR TITLE
Improve scheduler readability

### DIFF
--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/LifeEssenceCaringTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/LifeEssenceCaringTask.java
@@ -14,26 +14,31 @@ import cl.camodev.wosbot.serv.task.DelayedTask;
 
 public class LifeEssenceCaringTask extends DelayedTask {
 
+        private static final int IMAGE_MATCH_THRESHOLD = 90;
+        private static final int MAX_SCROLL_ATTEMPTS = 8;
+        private static final int MAX_BUTTON_SEARCH_ATTEMPTS = 3;
+
 
 	public LifeEssenceCaringTask(DTOProfiles profile, TpDailyTaskEnum dailyMission) {
 		super(profile, dailyMission);
 	}
 
-	// i should go to essence tree, check if there's daily attempt available, if not, reschedule till daily reset,
+        // Navigate to the essence tree and check if a daily attempt is available.
+        // If not, reschedule until the daily reset.
 	@Override
 	protected void execute() {
 
-		logInfo( "going life essence");
+                logInfo("Going to Life Essence menu");
 		emuManager.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(1, 509), new DTOPoint(24, 592));
-		// asegurarse de esta en el shortcut de ciudad
+                // Ensure we are in the city shortcut
 		sleepTask(2000);
 		emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(110, 270));
 		sleepTask(1000);
 
-		// hacer swipe hacia abajo
+                // Swipe down
 		emuManager.executeSwipe(EMULATOR_NUMBER, new DTOPoint(220, 845), new DTOPoint(220, 94));
 		sleepTask(1000);
-		DTOImageSearchResult lifeEssenceMenu = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.LIFE_ESSENCE_MENU.getTemplate(),  90);
+                DTOImageSearchResult lifeEssenceMenu = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.LIFE_ESSENCE_MENU.getTemplate(), IMAGE_MATCH_THRESHOLD);
 
 		if (lifeEssenceMenu.isFound()) {
 			emuManager.tapAtRandomPoint(EMULATOR_NUMBER, lifeEssenceMenu.getPoint(), lifeEssenceMenu.getPoint());
@@ -45,22 +50,22 @@ public class LifeEssenceCaringTask extends DelayedTask {
 			emuManager.tapAtPoint(EMULATOR_NUMBER, new DTOPoint(670, 100));
 			sleepTask(2000);
 
-			DTOImageSearchResult dailyAttempt = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.LIFE_ESSENCE_DAILY_CARING_AVAILABLE.getTemplate(), 90);
+                        DTOImageSearchResult dailyAttempt = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.LIFE_ESSENCE_DAILY_CARING_AVAILABLE.getTemplate(), IMAGE_MATCH_THRESHOLD);
 			if (dailyAttempt.isFound()) {
 				logInfo( "Daily attempt available, proceeding with caring");
 
-				// bebo buscar y scrollear unas 7-8 veces, si no encuentro, reschedule de una hora
+                                // Search and scroll several times; if not found, reschedule in one hour
 
-				for (int i = 0; i < 8; i++) {
-					DTOImageSearchResult caringAvailable = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.LIFE_ESSENCE_DAILY_CARING_GOTO_ISLAND.getTemplate(), 90);
+                                for (int i = 0; i < MAX_SCROLL_ATTEMPTS; i++) {
+                                        DTOImageSearchResult caringAvailable = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.LIFE_ESSENCE_DAILY_CARING_GOTO_ISLAND.getTemplate(), IMAGE_MATCH_THRESHOLD);
 					if (caringAvailable.isFound()) {
 						emuManager.tapAtRandomPoint(EMULATOR_NUMBER, caringAvailable.getPoint(), caringAvailable.getPoint());
 						sleepTask(5000);
 						logInfo( "Caring available, proceeding with caring");
-						// buscar el boton de caring, debo buscañpr un par de veces debido al movimiento
+                                                // Search for the caring button; try a couple times due to animation
 
-						for (int j = 0; j < 3; j++) {
-							DTOImageSearchResult caringButton = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.LIFE_ESSENCE_DAILY_CARING_BUTTON.getTemplate(),  90);
+                                                for (int j = 0; j < MAX_BUTTON_SEARCH_ATTEMPTS; j++) {
+                                                        DTOImageSearchResult caringButton = emuManager.searchTemplate(EMULATOR_NUMBER, EnumTemplates.LIFE_ESSENCE_DAILY_CARING_BUTTON.getTemplate(),  IMAGE_MATCH_THRESHOLD);
 							if (caringButton.isFound()) {
 								emuManager.tapAtRandomPoint(EMULATOR_NUMBER, caringButton.getPoint(), caringButton.getPoint());
 								sleepTask(5000);

--- a/wos-utiles/src/main/java/cl/camodev/utiles/UtilOCR.java
+++ b/wos-utiles/src/main/java/cl/camodev/utiles/UtilOCR.java
@@ -12,48 +12,48 @@ import net.sourceforge.tess4j.TesseractException;
 
 public class UtilOCR {
 
-	/**
-	 * Ejecuta OCR sobre una región específica de una imagen.
-	 *
-	 * @param imagePath Ruta a la imagen en el sistema de archivos.
-	 * @param p1        Primer punto que define la región (puede ser, por ejemplo, la esquina superior izquierda).
-	 * @param p2        Segundo punto que define la región (por ejemplo, la esquina inferior derecha).
-	 * @return El texto reconocido en la región.
-	 * @throws IOException              Si ocurre un error al cargar la imagen.
-	 * @throws TesseractException       Si ocurre un error durante el proceso de OCR.
-	 * @throws IllegalArgumentException Si la región especificada excede los límites de la imagen.
-	 */
+        /**
+         * Performs OCR on a specific region of an image.
+         *
+         * @param imagePath Path to the image on disk.
+         * @param p1        First point defining the region (e.g. top-left corner).
+         * @param p2        Second point defining the region (e.g. bottom-right corner).
+         * @return The text recognized in the region.
+         * @throws IOException              If the image cannot be loaded.
+         * @throws TesseractException       If an error occurs during OCR.
+         * @throws IllegalArgumentException If the specified region exceeds image bounds.
+         */
 	public static String ocrFromRegion(String imagePath, DTOPoint p1, DTOPoint p2) throws IOException, TesseractException {
-		// Cargar la imagen desde el path proporcionado
+                // Load image from the provided path
 		File imageFile = new File(imagePath);
 		BufferedImage image = ImageIO.read(imageFile);
 		if (image == null) {
-			throw new IOException("No se pudo cargar la imagen: " + imagePath);
+                        throw new IOException("Could not load image: " + imagePath);
 		}
 
-		// Calcular la región a extraer:
-		// Se determina el punto superior izquierdo (x, y) y se calcula el ancho y alto
+                // Calculate the region to extract:
+                // Determine the top-left point (x, y) and compute width and height
 		int x = (int) Math.min(p1.getX(), p2.getX());
 		int y = (int) Math.min(p1.getY(), p2.getY());
 		int width = (int) Math.abs(p1.getX() - p2.getX());
 		int height = (int) Math.abs(p1.getY() - p2.getY());
 
-		// Validar que la región no se salga de los límites de la imagen
+                // Validate that the region stays within the image bounds
 		if (x + width > image.getWidth() || y + height > image.getHeight()) {
-			throw new IllegalArgumentException("La región especificada se sale de los límites de la imagen.");
+                        throw new IllegalArgumentException("Specified region is outside the image bounds.");
 		}
 
-		// Extraer la subimagen (la región de interés)
+                // Extract the subimage (region of interest)
 		BufferedImage subImage = image.getSubimage(x, y, width, height);
 
-		// Configurar Tesseract
+                // Configure Tesseract
 		Tesseract tesseract = new Tesseract();
-		// Establece la ruta a la carpeta tessdata (asegúrate de que la ruta sea correcta)
+                // Set the path to the tessdata folder
 		tesseract.setDatapath("/lib/tesseract");
-		// Establecer el idioma; por ejemplo, "spa" para español
+                // Set the language (e.g. "eng")
 		tesseract.setLanguage("eng");
 
-		// Ejecutar OCR sobre la subimagen y devolver el resultado
+                // Run OCR on the subimage and return the result
 		return tesseract.doOCR(subImage);
 	}
 


### PR DESCRIPTION
## Summary
- rename `buscarTemplate` to `findTemplate` and update callers
- translate emulator manager comments and rename `adquireEmulatorSlot`
- use constants and clearer naming in task queue
- add match threshold constants to LifeEssence caring task


