### PR TITLE
Show selected profile with custom header image

### DIFF
--- a/wos-hmi/src/main/java/cl/camodev/wosbot/launcher/view/LauncherLayoutController.java
+++ b/wos-hmi/src/main/java/cl/camodev/wosbot/launcher/view/LauncherLayoutController.java
@@ -47,6 +47,8 @@ import javafx.scene.control.Button;
 import javafx.scene.control.ButtonBar;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.Label;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
@@ -56,24 +58,32 @@ import javafx.stage.Stage;
 
 public class LauncherLayoutController implements IProfileLoadListener {
 
-	@FXML
-	private VBox buttonsContainer;
-	@FXML
-	private Button buttonStartStop;
+        private static final double PROFILE_IMAGE_SIZE = 40.0;
 
-	@FXML
-	private Button buttonPauseResume;
+        @FXML
+        private VBox buttonsContainer;
+        @FXML
+        private Button buttonStartStop;
 
-	@FXML
-	private AnchorPane mainContentPane;
+        @FXML
+        private Button buttonPauseResume;
 
-	@FXML
-	private Label labelRunTime;
+        @FXML
+        private AnchorPane mainContentPane;
 
-	@FXML
-	private Label labelVersion;
+        @FXML
+        private Label labelRunTime;
 
-	private Stage stage;
+        @FXML
+        private Label labelVersion;
+
+        @FXML
+        private ImageView imageProfile;
+
+        @FXML
+        private Label labelProfileName;
+
+        private Stage stage;
 
 	private LauncherActionController actionController;
 
@@ -96,18 +106,26 @@ public class LauncherLayoutController implements IProfileLoadListener {
 		initializeLogModule();
 		initializeProfileModule();
 		initializeModules();
-		initializeExternalLibraries();
-		initializeEmulatorManager();
-		showVersion();
+                initializeExternalLibraries();
+                initializeEmulatorManager();
+                showVersion();
+                initializeProfileHeader();
 
-	}
+        }
 
-	private void showVersion() {
-		String version = getVersion();
-		labelVersion.setText("Version: " + version);
-	}
+        private void showVersion() {
+                String version = getVersion();
+                labelVersion.setText("Version: " + version);
+        }
 
-	private String getVersion() {
+        private void initializeProfileHeader() {
+                imageProfile.setFitHeight(PROFILE_IMAGE_SIZE);
+                imageProfile.setFitWidth(PROFILE_IMAGE_SIZE);
+                imageProfile.setImage(null);
+                labelProfileName.setText("");
+        }
+
+        private String getVersion() {
 		// If running as JAR
 		Package pkg = getClass().getPackage();
 		if (pkg != null && pkg.getImplementationVersion() != null) {
@@ -371,13 +389,20 @@ public class LauncherLayoutController implements IProfileLoadListener {
 		return type.cast(controller);
 	}
 
-	@Override
-	public void onProfileLoad(ProfileAux profile) {
-		String version = getVersion();
-		stage.setTitle("Whiteout Survival Bot v" + version + " - " + profile.getName());
-		buttonStartStop.setDisable(false);
-		buttonPauseResume.setDisable(true);
-	}
+        @Override
+        public void onProfileLoad(ProfileAux profile) {
+                labelProfileName.setText(profile.getName());
+                String photoPath = profile.getConfig(EnumConfigurationKey.PROFILE_IMAGE_PATH_STRING, String.class);
+                if (photoPath != null && !photoPath.trim().isEmpty() && new File(photoPath).exists()) {
+                        imageProfile.setImage(new Image(new File(photoPath).toURI().toString()));
+                } else {
+                        imageProfile.setImage(null);
+                }
+                String version = getVersion();
+                stage.setTitle("Whiteout Survival Bot v" + version + " - " + profile.getName());
+                buttonStartStop.setDisable(false);
+                buttonPauseResume.setDisable(true);
+        }
 
 	public void onBotStateChange(DTOBotState botState) {
 		if (botState != null) {

--- a/wos-hmi/src/main/java/cl/camodev/wosbot/profile/view/EditProfileController.java
+++ b/wos-hmi/src/main/java/cl/camodev/wosbot/profile/view/EditProfileController.java
@@ -15,6 +15,7 @@ import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
+import javafx.scene.shape.Circle;
 
 import java.net.URL;
 import java.io.File;
@@ -22,7 +23,7 @@ import java.util.ResourceBundle;
 
 public class EditProfileController implements Initializable {
 
-    private static final double PROFILE_IMAGE_SIZE = 80.0;
+    private static final double PROFILE_IMAGE_DIAMETER = 80.0;
 
     @FXML
     private TextField txtProfileName;
@@ -63,8 +64,9 @@ public class EditProfileController implements Initializable {
             }
         });
 
-        imageProfile.setFitHeight(PROFILE_IMAGE_SIZE);
-        imageProfile.setFitWidth(PROFILE_IMAGE_SIZE);
+        imageProfile.setFitHeight(PROFILE_IMAGE_DIAMETER);
+        imageProfile.setFitWidth(PROFILE_IMAGE_DIAMETER);
+        imageProfile.setClip(new Circle(PROFILE_IMAGE_DIAMETER / 2, PROFILE_IMAGE_DIAMETER / 2, PROFILE_IMAGE_DIAMETER / 2));
         imageProfile.setImage(null);
     }
 

--- a/wos-hmi/src/main/java/cl/camodev/wosbot/profile/view/EditProfileController.java
+++ b/wos-hmi/src/main/java/cl/camodev/wosbot/profile/view/EditProfileController.java
@@ -1,5 +1,6 @@
 package cl.camodev.wosbot.profile.view;
 
+import cl.camodev.wosbot.console.enumerable.EnumConfigurationKey;
 import cl.camodev.wosbot.console.enumerable.EnumTpMessageSeverity;
 import cl.camodev.wosbot.profile.controller.ProfileManagerActionController;
 import cl.camodev.wosbot.profile.model.ProfileAux;
@@ -10,12 +11,18 @@ import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.TextField;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
+import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 
 import java.net.URL;
+import java.io.File;
 import java.util.ResourceBundle;
 
 public class EditProfileController implements Initializable {
+
+    private static final double PROFILE_IMAGE_SIZE = 80.0;
 
     @FXML
     private TextField txtProfileName;
@@ -31,6 +38,9 @@ public class EditProfileController implements Initializable {
 
     @FXML
     private Button btnCancel;
+
+    @FXML
+    private ImageView imageProfile;
 
     private ProfileAux profileToEdit;
     private ProfileManagerActionController actionController;
@@ -52,6 +62,10 @@ public class EditProfileController implements Initializable {
                 txtEmulatorNumber.setText(oldValue);
             }
         });
+
+        imageProfile.setFitHeight(PROFILE_IMAGE_SIZE);
+        imageProfile.setFitWidth(PROFILE_IMAGE_SIZE);
+        imageProfile.setImage(null);
     }
 
     public void setProfileToEdit(ProfileAux profile) {
@@ -76,6 +90,14 @@ public class EditProfileController implements Initializable {
             txtProfileName.setText(profileToEdit.getName());
             txtEmulatorNumber.setText(profileToEdit.getEmulatorNumber());
             chkEnabled.setSelected(profileToEdit.isEnabled());
+
+            String photoPath = profileToEdit.getConfig(EnumConfigurationKey.PROFILE_IMAGE_PATH_STRING, String.class);
+            if (photoPath != null && !photoPath.trim().isEmpty()) {
+                File photoFile = new File(photoPath);
+                if (photoFile.exists()) {
+                    imageProfile.setImage(new Image(photoFile.toURI().toString()));
+                }
+            }
         }
     }
 
@@ -159,5 +181,19 @@ public class EditProfileController implements Initializable {
         }
 
         return true;
+    }
+
+    @FXML
+    private void handleInsertPhoto() {
+        FileChooser fileChooser = new FileChooser();
+        fileChooser.setTitle("Select Profile Photo");
+        fileChooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("PNG Images", "*.png"));
+        File selectedFile = fileChooser.showOpenDialog(dialogStage);
+        if (selectedFile != null) {
+            imageProfile.setImage(new Image(selectedFile.toURI().toString()));
+            if (profileToEdit != null) {
+                profileToEdit.setConfig(EnumConfigurationKey.PROFILE_IMAGE_PATH_STRING, selectedFile.getAbsolutePath());
+            }
+        }
     }
 }

--- a/wos-hmi/src/main/java/cl/camodev/wosbot/profile/view/ProfileManagerLayoutController.java
+++ b/wos-hmi/src/main/java/cl/camodev/wosbot/profile/view/ProfileManagerLayoutController.java
@@ -62,7 +62,7 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 	@FXML
 	private Button btnBulkUpdate;
 	private Long loadedProfileId;
-	private List<IProfileLoadListener> profileLoadListeners;
+        private List<IProfileLoadListener> profileLoadListeners;
 
 	@FXML
 	private void initialize() {
@@ -76,24 +76,24 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 		profileManagerActionController = new ProfileManagerActionController(this);
 	}
 
-	private void initializeTableView() {
+        private void initializeTableView() {
 		profiles = FXCollections.observableArrayList();
 
 		columnProfileName.setCellValueFactory(cellData -> cellData.getValue().nameProperty());
 		columnEmulatorNumber.setCellValueFactory(cellData -> cellData.getValue().emulatorNumberProperty());
-		columnStatus.setCellValueFactory(cellData -> cellData.getValue().statusProperty());
+               columnStatus.setCellValueFactory(cellData -> cellData.getValue().statusProperty());
 
-		// Add double-click event handler to open edit dialog
-		tableviewLogMessages.setRowFactory(tv -> {
-			javafx.scene.control.TableRow<ProfileAux> row = new javafx.scene.control.TableRow<>();
-			row.setOnMouseClicked(event -> {
-				if (event.getClickCount() == 2 && (!row.isEmpty())) {
-					ProfileAux selectedProfile = row.getItem();
-					profileManagerActionController.showEditProfileDialog(selectedProfile, tableviewLogMessages);
-				}
-			});
-			return row;
-		});
+               // Add double-click event handler to open edit dialog
+               tableviewLogMessages.setRowFactory(tv -> {
+                        javafx.scene.control.TableRow<ProfileAux> row = new javafx.scene.control.TableRow<>();
+                        row.setOnMouseClicked(event -> {
+                                if (event.getClickCount() == 2 && (!row.isEmpty())) {
+                                        ProfileAux selectedProfile = row.getItem();
+                                        profileManagerActionController.showEditProfileDialog(selectedProfile, tableviewLogMessages);
+                                }
+                        });
+                        return row;
+               });
 
 		columnDelete.setCellFactory(new Callback<TableColumn<ProfileAux, Void>, TableCell<ProfileAux, Void>>() {
 			@Override
@@ -291,12 +291,16 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 	}
 
 	@FXML
-	void handleButtonBulkUpdateProfiles(ActionEvent event) {
-		profileManagerActionController.showBulkUpdateDialog(loadedProfileId, profiles, btnBulkUpdate);
-	}
+        void handleButtonBulkUpdateProfiles(ActionEvent event) {
+                profileManagerActionController.showBulkUpdateDialog(loadedProfileId, profiles, btnBulkUpdate);
+        }
 
-	public void loadProfiles() {
-		profileManagerActionController.loadProfiles(dtoProfiles -> {
+       public boolean saveProfile(ProfileAux profile) {
+               return profileManagerActionController.saveProfile(profile);
+       }
+
+        public void loadProfiles() {
+                profileManagerActionController.loadProfiles(dtoProfiles -> {
 			Platform.runLater(() -> {
 				profiles.clear();
 				dtoProfiles.forEach(dtoProfile -> {

--- a/wos-hmi/src/main/resources/cl/camodev/wosbot/launcher/view/LauncherLayout.fxml
+++ b/wos-hmi/src/main/resources/cl/camodev/wosbot/launcher/view/LauncherLayout.fxml
@@ -8,9 +8,10 @@
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.shape.Circle?>
 
 <GridPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="508.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1">
     
@@ -28,17 +29,18 @@
         <HBox>
             <children>
 
-                <VBox fx:id="buttonsContainer" prefHeight="325.0" prefWidth="140.0" style="-fx-border-color: black;">
+                <VBox fx:id="buttonsContainer" prefHeight="325.0" prefWidth="140.0" style="-fx-background-color: transparent;">
                    <children>
-                      <VBox alignment="CENTER" spacing="5.0" style="-fx-background-color: #2E2E2E; -fx-padding: 10;">
+                      <VBox alignment="TOP_CENTER" spacing="8.0" style="-fx-background-color: #2E2E2E; -fx-padding: 15; -fx-background-radius: 5;">
                          <children>
-                            <StackPane>
+                            <StackPane alignment="CENTER">
                                <children>
+                                  <Circle fx:id="imagePlaceholder" fill="#555555" radius="64.0" />
                                   <ImageView fx:id="imageProfile" pickOnBounds="true" preserveRatio="true" />
-                                  <Button fx:id="buttonChangePhoto" mnemonicParsing="false" onAction="#handleChangePhoto" text="Change" StackPane.alignment="BOTTOM_RIGHT" style="-fx-background-color: #555555; -fx-text-fill: white; -fx-font-size: 10px;" />
                                </children>
                             </StackPane>
                             <Label fx:id="labelProfileName" style="-fx-text-fill: white; -fx-font-size: 14px;" />
+                            <Button fx:id="buttonChangePhoto" mnemonicParsing="false" onAction="#handleChangePhoto" text="Upload Photo" style="-fx-background-color: #555555; -fx-text-fill: white; -fx-font-size: 10px;" />
                          </children>
                       </VBox>
                    </children>

--- a/wos-hmi/src/main/resources/cl/camodev/wosbot/launcher/view/LauncherLayout.fxml
+++ b/wos-hmi/src/main/resources/cl/camodev/wosbot/launcher/view/LauncherLayout.fxml
@@ -3,6 +3,7 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
+<?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
@@ -27,9 +28,18 @@
             <children>
 
                 <VBox fx:id="buttonsContainer" prefHeight="325.0" prefWidth="140.0" style="-fx-border-color: black;">
-               <HBox.margin>
-                  <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
-               </HBox.margin></VBox>
+                   <children>
+                      <HBox alignment="CENTER_LEFT" spacing="10.0" style="-fx-background-color: #2E2E2E; -fx-padding: 10;">
+                         <children>
+                            <ImageView fx:id="imageProfile" pickOnBounds="true" preserveRatio="true" />
+                            <Label fx:id="labelProfileName" style="-fx-text-fill: white; -fx-font-size: 14px;" />
+                         </children>
+                      </HBox>
+                   </children>
+                   <HBox.margin>
+                      <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
+                   </HBox.margin>
+                </VBox>
 
                 <AnchorPane fx:id="mainContentPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="2.0" prefWidth="2.0" style="-fx-border-color: black;" HBox.hgrow="ALWAYS">
                <HBox.margin>

--- a/wos-hmi/src/main/resources/cl/camodev/wosbot/launcher/view/LauncherLayout.fxml
+++ b/wos-hmi/src/main/resources/cl/camodev/wosbot/launcher/view/LauncherLayout.fxml
@@ -8,6 +8,7 @@
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
@@ -29,12 +30,17 @@
 
                 <VBox fx:id="buttonsContainer" prefHeight="325.0" prefWidth="140.0" style="-fx-border-color: black;">
                    <children>
-                      <HBox alignment="CENTER_LEFT" spacing="10.0" style="-fx-background-color: #2E2E2E; -fx-padding: 10;">
+                      <VBox alignment="CENTER" spacing="5.0" style="-fx-background-color: #2E2E2E; -fx-padding: 10;">
                          <children>
-                            <ImageView fx:id="imageProfile" pickOnBounds="true" preserveRatio="true" />
+                            <StackPane>
+                               <children>
+                                  <ImageView fx:id="imageProfile" pickOnBounds="true" preserveRatio="true" />
+                                  <Button fx:id="buttonChangePhoto" mnemonicParsing="false" onAction="#handleChangePhoto" text="Change" StackPane.alignment="BOTTOM_RIGHT" style="-fx-background-color: #555555; -fx-text-fill: white; -fx-font-size: 10px;" />
+                               </children>
+                            </StackPane>
                             <Label fx:id="labelProfileName" style="-fx-text-fill: white; -fx-font-size: 14px;" />
                          </children>
-                      </HBox>
+                      </VBox>
                    </children>
                    <HBox.margin>
                       <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />

--- a/wos-hmi/src/main/resources/cl/camodev/wosbot/profile/view/EditProfile.fxml
+++ b/wos-hmi/src/main/resources/cl/camodev/wosbot/profile/view/EditProfile.fxml
@@ -5,6 +5,7 @@
 <?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TextField?>
+<?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
@@ -14,6 +15,12 @@
 <VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="250.0" prefWidth="400.0" spacing="10.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="cl.camodev.wosbot.profile.view.EditProfileController">
    <children>
       <Label style="-fx-font-size: 16px; -fx-font-weight: bold;" text="Edit Profile" />
+      <HBox alignment="CENTER_LEFT" spacing="10.0">
+         <children>
+            <ImageView fx:id="imageProfile" fitHeight="80.0" fitWidth="80.0" pickOnBounds="true" preserveRatio="true" />
+            <Button mnemonicParsing="false" onAction="#handleInsertPhoto" text="Insert Photo" />
+         </children>
+      </HBox>
 
       <GridPane hgap="10.0" vgap="10.0">
         <columnConstraints>

--- a/wos-ot/src/main/java/cl/camodev/wosbot/console/enumerable/EnumConfigurationKey.java
+++ b/wos-ot/src/main/java/cl/camodev/wosbot/console/enumerable/EnumConfigurationKey.java
@@ -91,8 +91,9 @@ public enum EnumConfigurationKey {
 	
 	BOOL_BANK("false",Boolean.class),
 	INT_BANK_DELAY("1",Integer.class),
-	BOOL_MYSTERY_SHOP("false",Boolean.class),
-	;
+        BOOL_MYSTERY_SHOP("false",Boolean.class),
+        PROFILE_IMAGE_PATH_STRING("", String.class),
+        ;
 	//@formatter:on
     private final String defaultValue;
     private final Class<?> type;


### PR DESCRIPTION
## Summary
- Persist profile photo path using a new configuration key
- Let users choose and preview a PNG in the profile editor
- Load the stored photo in the launcher sidebar if provided

