### PR TITLE
Isolate profile database and allow resizing profile dialog

### DIFF
--- a/wos-hmi/src/main/java/cl/camodev/wosbot/profile/controller/ProfileManagerActionController.java
+++ b/wos-hmi/src/main/java/cl/camodev/wosbot/profile/controller/ProfileManagerActionController.java
@@ -30,8 +30,10 @@ import javafx.stage.Modality;
 import javafx.stage.Stage;
 
 public class ProfileManagerActionController implements IProfileStatusChangeListener {
+        private static final double EDIT_DIALOG_MIN_WIDTH = 600;
+        private static final double EDIT_DIALOG_MIN_HEIGHT = 400;
 
-	private final ProfileManagerLayoutController profileManagerLayoutController;
+        private final ProfileManagerLayoutController profileManagerLayoutController;
 
 	private Stage newProfileStage;
 
@@ -238,16 +240,16 @@ public class ProfileManagerActionController implements IProfileStatusChangeListe
 			Scene scene = new Scene(root);
 			scene.getStylesheets().add(ILauncherConstants.getCssPath());
 
-			dialogStage.setScene(scene);
-			dialogStage.initModality(Modality.WINDOW_MODAL);
-			dialogStage.initOwner(ownerNode.getScene().getWindow());
-			dialogStage.setResizable(false);
+                        dialogStage.setScene(scene);
+                        dialogStage.initModality(Modality.WINDOW_MODAL);
+                        dialogStage.initOwner(ownerNode.getScene().getWindow());
+                        dialogStage.setResizable(false);
 
-			// Setup the dialog with current data
-			dialogController.setupDialog(templateProfile, new ArrayList<>(profiles), dialogStage);
+                        // Setup the dialog with current data
+                        dialogController.setupDialog(templateProfile, new ArrayList<>(profiles), dialogStage);
 
-			// Show dialog and wait for user response
-			dialogStage.showAndWait();
+                        // Show dialog and wait for user response
+                        dialogStage.showAndWait();
 
 			// Process the result if user confirmed
 			if (dialogController.isUpdateConfirmed()) {
@@ -305,10 +307,14 @@ public class ProfileManagerActionController implements IProfileStatusChangeListe
 			Scene scene = new Scene(root);
 			scene.getStylesheets().add(ILauncherConstants.getCssPath());
 
-			dialogStage.setScene(scene);
-			dialogStage.initModality(Modality.WINDOW_MODAL);
-			dialogStage.initOwner(ownerNode.getScene().getWindow());
-			dialogStage.setResizable(false);
+                        dialogStage.setScene(scene);
+                        dialogStage.initModality(Modality.WINDOW_MODAL);
+                        dialogStage.initOwner(ownerNode.getScene().getWindow());
+                        dialogStage.setResizable(true);
+                        dialogStage.setMinWidth(EDIT_DIALOG_MIN_WIDTH);
+                        dialogStage.setMinHeight(EDIT_DIALOG_MIN_HEIGHT);
+                        dialogStage.setWidth(EDIT_DIALOG_MIN_WIDTH);
+                        dialogStage.setHeight(EDIT_DIALOG_MIN_HEIGHT);
 
 			// Set the dialog stage in the controller
 			dialogController.setDialogStage(dialogStage);

--- a/wos-hmi/src/main/java/cl/camodev/wosbot/profile/view/ProfileManagerLayoutController.java
+++ b/wos-hmi/src/main/java/cl/camodev/wosbot/profile/view/ProfileManagerLayoutController.java
@@ -43,7 +43,8 @@ import javafx.util.Duration;
 
 public class ProfileManagerLayoutController implements IProfileChangeObserver {
 
-    private final ExecutorService profileQueueExecutor = Executors.newVirtualThreadPerTaskExecutor();
+    // Serialize profile operations to avoid SQLite write contention
+    private final ExecutorService profileQueueExecutor = Executors.newSingleThreadExecutor();
 	private ProfileManagerActionController profileManagerActionController;
 	private ObservableList<ProfileAux> profiles;
 	private SortedList<ProfileAux> sortedProfiles;

--- a/wos-hmi/src/main/resources/cl/camodev/wosbot/profile/view/EditProfile.fxml
+++ b/wos-hmi/src/main/resources/cl/camodev/wosbot/profile/view/EditProfile.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="250.0" prefWidth="400.0" spacing="10.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="cl.camodev.wosbot.profile.view.EditProfileController">
+<VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" spacing="10.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="cl.camodev.wosbot.profile.view.EditProfileController">
    <children>
       <Label style="-fx-font-size: 16px; -fx-font-weight: bold;" text="Edit Profile" />
       <HBox alignment="CENTER_LEFT" spacing="10.0">

--- a/wos-persistence/src/main/resources/META-INF/persistence.xml
+++ b/wos-persistence/src/main/resources/META-INF/persistence.xml
@@ -8,8 +8,8 @@
 
 			<property name="jakarta.persistence.jdbc.driver"
 				value="org.sqlite.JDBC" />
-			<property name="jakarta.persistence.jdbc.url"
-				value="jdbc:sqlite:database.db" />
+                        <property name="jakarta.persistence.jdbc.url"
+                                value="jdbc:sqlite:profiles.db" />
 
 			<property name="hibernate.dialect"
 				value="org.hibernate.community.dialect.SQLiteDialect" />


### PR DESCRIPTION
## Summary
- direct profile persistence to a dedicated `profiles.db` file
- allow the edit profile dialog to be resized with a larger default size
- serialize profile save operations on a single-thread executor to avoid SQLite write contention

