### PR TITLE
Add profile import/export utilities

### DIFF
--- a/wos-hmi/src/main/java/cl/camodev/wosbot/profile/view/ProfileManagerLayoutController.java
+++ b/wos-hmi/src/main/java/cl/camodev/wosbot/profile/view/ProfileManagerLayoutController.java
@@ -1,5 +1,6 @@
 package cl.camodev.wosbot.profile.view;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -40,6 +41,7 @@ import javafx.scene.shape.Circle;
 import javafx.scene.shape.Rectangle;
 import javafx.util.Callback;
 import javafx.util.Duration;
+import javafx.stage.FileChooser;
 
 public class ProfileManagerLayoutController implements IProfileChangeObserver {
 
@@ -57,11 +59,15 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 	@FXML
 	private TableColumn<ProfileAux, Boolean> columnEnabled;
 	@FXML
-	private TableColumn<ProfileAux, String> columnProfileName;
-	@FXML
-	private TableColumn<ProfileAux, String> columnStatus;
-	@FXML
-	private Button btnBulkUpdate;
+        private TableColumn<ProfileAux, String> columnProfileName;
+        @FXML
+        private TableColumn<ProfileAux, String> columnStatus;
+        @FXML
+        private Button btnBulkUpdate;
+       @FXML
+       private Button btnExportProfiles;
+       @FXML
+       private Button btnImportProfiles;
 	private Long loadedProfileId;
         private List<IProfileLoadListener> profileLoadListeners;
 
@@ -295,6 +301,41 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
         void handleButtonBulkUpdateProfiles(ActionEvent event) {
                 profileManagerActionController.showBulkUpdateDialog(loadedProfileId, profiles, btnBulkUpdate);
         }
+
+       @FXML
+       void handleButtonExportProfiles(ActionEvent event) {
+               FileChooser fileChooser = new FileChooser();
+               fileChooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("JSON Files", "*.json"));
+               File selectedFile = fileChooser.showSaveDialog(btnExportProfiles.getScene().getWindow());
+               if (selectedFile != null) {
+                       boolean exported = profileManagerActionController.exportProfiles(selectedFile);
+                       Alert alert;
+                       if (exported) {
+                               alert = new Alert(Alert.AlertType.INFORMATION, "Profiles exported successfully", ButtonType.OK);
+                       } else {
+                               alert = new Alert(Alert.AlertType.ERROR, "Error exporting profiles", ButtonType.OK);
+                       }
+                       alert.showAndWait();
+               }
+       }
+
+       @FXML
+       void handleButtonImportProfiles(ActionEvent event) {
+               FileChooser fileChooser = new FileChooser();
+               fileChooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("JSON Files", "*.json"));
+               File selectedFile = fileChooser.showOpenDialog(btnImportProfiles.getScene().getWindow());
+               if (selectedFile != null) {
+                       boolean imported = profileManagerActionController.importProfiles(selectedFile);
+                       Alert alert;
+                       if (imported) {
+                               alert = new Alert(Alert.AlertType.INFORMATION, "Profiles imported successfully", ButtonType.OK);
+                               loadProfiles();
+                       } else {
+                               alert = new Alert(Alert.AlertType.ERROR, "Error importing profiles", ButtonType.OK);
+                       }
+                       alert.showAndWait();
+               }
+       }
 
        public boolean saveProfile(ProfileAux profile) {
                return profileManagerActionController.saveProfile(profile);

--- a/wos-hmi/src/main/resources/cl/camodev/wosbot/profile/view/ProfileManagerLayout.fxml
+++ b/wos-hmi/src/main/resources/cl/camodev/wosbot/profile/view/ProfileManagerLayout.fxml
@@ -35,6 +35,16 @@
       </TableView>
       <HBox alignment="CENTER_RIGHT" prefHeight="100.0" prefWidth="200.0" GridPane.rowIndex="1">
          <children>
+            <Button fx:id="btnExportProfiles" mnemonicParsing="false" onAction="#handleButtonExportProfiles" text="EXPORT">
+               <HBox.margin>
+                  <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
+               </HBox.margin>
+            </Button>
+            <Button fx:id="btnImportProfiles" mnemonicParsing="false" onAction="#handleButtonImportProfiles" text="IMPORT">
+               <HBox.margin>
+                  <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
+               </HBox.margin>
+            </Button>
             <Button fx:id="btnBulkUpdate" mnemonicParsing="false" onAction="#handleButtonBulkUpdateProfiles" text="BULK UPDATE PROFILES">
                <HBox.margin>
                   <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />

--- a/wos-utils/pom.xml
+++ b/wos-utils/pom.xml
@@ -10,12 +10,12 @@
 	<artifactId>wos-utils</artifactId>
 	<name>Utiles</name>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.openpnp</groupId>
-			<artifactId>opencv</artifactId>
-			<version>4.9.0-0</version>
-		</dependency>
+        <dependencies>
+                <dependency>
+                        <groupId>org.openpnp</groupId>
+                        <artifactId>opencv</artifactId>
+                        <version>4.9.0-0</version>
+                </dependency>
 		<!-- https://mvnrepository.com/artifact/net.sourceforge.tess4j/tess4j -->
 		<dependency>
 			<groupId>net.sourceforge.tess4j</groupId>
@@ -23,16 +23,21 @@
 			<version>5.14.0</version>
 		</dependency>
 
-		<dependency>
-			<groupId>cl.camodev</groupId>
-			<artifactId>wos-ot</artifactId>
-			<version>${revision}</version>
-		</dependency>
-		<!-- API -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>cl.camodev</groupId>
+                        <artifactId>wos-ot</artifactId>
+                        <version>${revision}</version>
+                </dependency>
+                <dependency>
+                        <groupId>com.google.code.gson</groupId>
+                        <artifactId>gson</artifactId>
+                        <version>2.10.1</version>
+                </dependency>
+                <!-- API -->
+                <dependency>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                </dependency>
 		<!-- Binding/implementación en tiempo de ejecución -->
 		<dependency>
                         <groupId>ch.qos.logback</groupId>

--- a/wos-utils/src/main/java/cl/camodev/utiles/ProfileIO.java
+++ b/wos-utils/src/main/java/cl/camodev/utiles/ProfileIO.java
@@ -1,0 +1,59 @@
+package cl.camodev.utiles;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+
+import cl.camodev.wosbot.ot.DTOProfiles;
+
+/**
+ * Utility class for importing and exporting profiles as JSON.
+ */
+public final class ProfileIO {
+
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+    private ProfileIO() {
+    }
+
+    /**
+     * Writes the provided profiles to the given path in JSON format.
+     *
+     * @param profiles the profiles to serialize
+     * @param path the destination file
+     * @throws IOException if an I/O error occurs
+     */
+    public static void writeProfiles(List<DTOProfiles> profiles, Path path) throws IOException {
+        if (profiles == null || path == null) {
+            throw new IllegalArgumentException("Profiles and path must not be null");
+        }
+        Files.createDirectories(path.getParent());
+        try (Writer writer = Files.newBufferedWriter(path)) {
+            GSON.toJson(profiles, writer);
+        }
+    }
+
+    /**
+     * Reads profiles from the given JSON file.
+     *
+     * @param path the path to the JSON file
+     * @return the list of profiles
+     * @throws IOException if an I/O error occurs
+     */
+    public static List<DTOProfiles> readProfiles(Path path) throws IOException {
+        if (path == null) {
+            throw new IllegalArgumentException("Path must not be null");
+        }
+        try (Reader reader = Files.newBufferedReader(path)) {
+            return GSON.fromJson(reader, new TypeToken<List<DTOProfiles>>() {
+            }.getType());
+        }
+    }
+}

--- a/wos-utils/src/test/java/cl/camodev/utiles/ProfileIOTest.java
+++ b/wos-utils/src/test/java/cl/camodev/utiles/ProfileIOTest.java
@@ -1,0 +1,34 @@
+package cl.camodev.utiles;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import cl.camodev.wosbot.ot.DTOConfig;
+import cl.camodev.wosbot.ot.DTOProfiles;
+
+class ProfileIOTest {
+
+    @Test
+    void writeAndReadProfiles() throws Exception {
+        DTOProfiles profile = new DTOProfiles(1L, "test", "1", true);
+        profile.getConfigs().add(new DTOConfig(1L, "KEY", "value"));
+        List<DTOProfiles> profiles = List.of(profile);
+
+        Path temp = Files.createTempFile("profiles", ".json");
+        ProfileIO.writeProfiles(profiles, temp);
+
+        List<DTOProfiles> loaded = ProfileIO.readProfiles(temp);
+        assertEquals(1, loaded.size());
+        DTOProfiles loadedProfile = loaded.get(0);
+        assertEquals("test", loadedProfile.getName());
+        assertEquals("1", loadedProfile.getEmulatorNumber());
+        assertTrue(loadedProfile.getEnabled());
+        assertEquals("value", loadedProfile.getConfigs().get(0).getValor());
+    }
+}


### PR DESCRIPTION
## Summary
- add JSON ProfileIO utility for serializing DTOProfiles
- expose import and export actions in profile manager UI
- wire controllers to load/save profiles via ProfileIO with validation

## Testing
- `mvn -pl wos-utils,wos-hmi -am test`

------
https://chatgpt.com/codex/tasks/task_e_688ef81e5d20832fb9f911cc7fe8a35b