### PR TITLE
refactor: add per-profile persistence and update connection provider

### DIFF
--- a/wos-hmi/src/main/java/cl/camodev/wosbot/profile/model/ProfileAux.java
+++ b/wos-hmi/src/main/java/cl/camodev/wosbot/profile/model/ProfileAux.java
@@ -113,32 +113,32 @@ public class ProfileAux {
 		this.configs = configs;
 	}
 
-	/**
-	 * Obtiene el valor de una configuración específica utilizando EnumConfigurationKey. Es un método genérico que devuelve el tipo correcto
-	 * basado en la clave.
-	 */
-	public <T> T getConfig(EnumConfigurationKey key, Class<T> clazz) {
-		Optional<ConfigAux> configOptional = configs.stream().filter(config -> config.getName().equalsIgnoreCase(key.name())).findFirst();
+        /**
+         * Retrieves the value for a specific configuration using {@link EnumConfigurationKey}.
+         * This generic method returns the correct type based on the key.
+         */
+        public <T> T getConfig(EnumConfigurationKey key, Class<T> clazz) {
+                Optional<ConfigAux> configOptional = configs.stream().filter(config -> config.getName().equalsIgnoreCase(key.name())).findFirst();
 
-		if (!configOptional.isPresent()) {
+                if (!configOptional.isPresent()) {
 
-			ConfigAux defaultConfig = new ConfigAux(key.name(), key.getDefaultValue());
-			configs.add(defaultConfig);
-		}
-		String valor = configOptional.map(ConfigAux::getValue).orElse(key.getDefaultValue());
+                        ConfigAux defaultConfig = new ConfigAux(key.name(), key.getDefaultValue());
+                        configs.add(defaultConfig);
+                }
+                String value = configOptional.map(ConfigAux::getValue).orElse(key.getDefaultValue());
 
-		return key.castValue(valor);
-	}
+                return key.castValue(value);
+        }
 
-	public <T> void setConfig(EnumConfigurationKey key, T value) {
-		String valorAAlmacenar = value.toString();
-		Optional<ConfigAux> configOptional = configs.stream().filter(config -> config.getName().equalsIgnoreCase(key.name())).findFirst();
+        public <T> void setConfig(EnumConfigurationKey key, T value) {
+                String valueToStore = value.toString();
+                Optional<ConfigAux> configOptional = configs.stream().filter(config -> config.getName().equalsIgnoreCase(key.name())).findFirst();
 
-		if (configOptional.isPresent()) {
-			configOptional.get().setValue(valorAAlmacenar);
-		} else {
-			ConfigAux nuevaConfig = new ConfigAux(key.name(), valorAAlmacenar);
-			configs.add(nuevaConfig);
-		}
-	}
+                if (configOptional.isPresent()) {
+                        configOptional.get().setValue(valueToStore);
+                } else {
+                        ConfigAux newConfig = new ConfigAux(key.name(), valueToStore);
+                        configs.add(newConfig);
+                }
+        }
 }

--- a/wos-hmi/src/main/java/cl/camodev/wosbot/profile/view/ProfileManagerLayoutController.java
+++ b/wos-hmi/src/main/java/cl/camodev/wosbot/profile/view/ProfileManagerLayoutController.java
@@ -351,9 +351,9 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 				profiles.clear();
 				dtoProfiles.forEach(dtoProfile -> {
 					ProfileAux profileAux = new ProfileAux(dtoProfile.getId(), dtoProfile.getName(), dtoProfile.getEmulatorNumber(), dtoProfile.getEnabled(), "NOT RUNNING");
-					dtoProfile.getConfigs().forEach(config -> {
-						profileAux.getConfigs().add(new ConfigAux(config.getNombreConfiguracion(), config.getValor()));
-					});
+                                        dtoProfile.getConfigs().forEach(config -> {
+                                                profileAux.getConfigs().add(new ConfigAux(config.getKey(), config.getValue()));
+                                        });
 					profiles.add(profileAux);
 				});
 

--- a/wos-hmi/src/main/java/cl/camodev/wosbot/taskmanager/controller/TaskManagerActionController.java
+++ b/wos-hmi/src/main/java/cl/camodev/wosbot/taskmanager/controller/TaskManagerActionController.java
@@ -7,6 +7,7 @@ import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import cl.camodev.wosbot.console.enumerable.EnumTpMessageSeverity;
 import cl.camodev.wosbot.console.enumerable.TpDailyTaskEnum;
@@ -29,6 +30,7 @@ import cl.camodev.wosbot.taskmanager.model.impl.TaskCallback;
 import cl.camodev.wosbot.taskmanager.model.impl.TaskStatusModel;
 import cl.camodev.wosbot.taskmanager.model.TaskManagerAux;
 import cl.camodev.wosbot.taskmanager.view.ScheduleTaskDialogController;
+import cl.camodev.wosbot.taskmanager.view.CopyTasksDialogController;
 import cl.camodev.wosbot.taskmanager.view.TaskManagerLayoutController;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
@@ -313,11 +315,43 @@ public class TaskManagerActionController implements ITaskStatusChangeListener {
 	/**
 	 * Helper method to find profile by ID
 	 */
-	public DTOProfiles findProfileById(Long profileId) {
-		List<DTOProfiles> allProfiles = ServProfiles.getServices().getProfiles();
-		return allProfiles.stream()
-			.filter(p -> p.getId().equals(profileId))
-			.findFirst()
-			.orElse(null);
-	}
+        public DTOProfiles findProfileById(Long profileId) {
+                List<DTOProfiles> allProfiles = ServProfiles.getServices().getProfiles();
+                return allProfiles.stream()
+                        .filter(p -> p.getId().equals(profileId))
+                        .findFirst()
+                        .orElse(null);
+        }
+
+       public List<DTOProfiles> getAllProfiles() {
+               return ServProfiles.getServices().getProfiles();
+       }
+
+       public void showCopyTasksDialog(DTOProfiles sourceProfile) {
+               try {
+                       FXMLLoader loader = new FXMLLoader(getClass().getResource("/cl/camodev/wosbot/taskmanager/view/CopyTasksDialog.fxml"));
+                       Parent root = loader.load();
+                       CopyTasksDialogController controller = loader.getController();
+                       controller.init(sourceProfile, this);
+
+                       Stage stage = new Stage();
+                       stage.setTitle("Copy Tasks");
+                       stage.initModality(Modality.APPLICATION_MODAL);
+                       stage.setScene(new Scene(root));
+                       stage.setResizable(false);
+                       stage.showAndWait();
+               } catch (Exception e) {
+                       ServLogs.getServices().appendLog(EnumTpMessageSeverity.ERROR, "TaskManager", "-", "Failed to show copy tasks dialog: " + e.getMessage());
+               }
+       }
+
+       public void copyTasksToProfiles(DTOProfiles sourceProfile, List<DTOProfiles> targets) {
+               List<Long> ids = targets.stream().map(DTOProfiles::getId).collect(Collectors.toList());
+               boolean copied = ServScheduler.getServices().copyDailyTasks(sourceProfile.getId(), ids);
+               if (copied) {
+                       ids.forEach(taskManagerLayoutController::refreshProfileTasks);
+               } else {
+                       ServLogs.getServices().appendLog(EnumTpMessageSeverity.WARNING, "TaskManager", "-", "Failed to copy tasks");
+               }
+       }
 }

--- a/wos-hmi/src/main/java/cl/camodev/wosbot/taskmanager/view/CopyTasksDialogController.java
+++ b/wos-hmi/src/main/java/cl/camodev/wosbot/taskmanager/view/CopyTasksDialogController.java
@@ -1,0 +1,87 @@
+package cl.camodev.wosbot.taskmanager.view;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import cl.camodev.wosbot.ot.DTOProfiles;
+import cl.camodev.wosbot.taskmanager.controller.TaskManagerActionController;
+import javafx.fxml.FXML;
+import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.Label;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+
+public class CopyTasksDialogController {
+
+    private final Map<CheckBox, DTOProfiles> profileMap = new HashMap<>();
+    private DTOProfiles sourceProfile;
+    private TaskManagerActionController actionController;
+
+    @FXML
+    private Label lblSourceProfile;
+
+    @FXML
+    private VBox vboxProfileList;
+
+    @FXML
+    private Button btnSelectAll;
+
+    @FXML
+    private Button btnDeselectAll;
+
+    public void init(DTOProfiles sourceProfile, TaskManagerActionController actionController) {
+        this.sourceProfile = sourceProfile;
+        this.actionController = actionController;
+        lblSourceProfile.setText("Copy tasks from: " + sourceProfile.getName());
+        loadProfiles();
+    }
+
+    private void loadProfiles() {
+        List<DTOProfiles> profiles = actionController.getAllProfiles();
+        for (DTOProfiles profile : profiles) {
+            if (profile.getId().equals(sourceProfile.getId())) {
+                continue;
+            }
+            CheckBox cb = new CheckBox(profile.getName());
+            vboxProfileList.getChildren().add(cb);
+            profileMap.put(cb, profile);
+        }
+    }
+
+    @FXML
+    private void handleSelectAll() {
+        profileMap.keySet().forEach(cb -> cb.setSelected(true));
+    }
+
+    @FXML
+    private void handleDeselectAll() {
+        profileMap.keySet().forEach(cb -> cb.setSelected(false));
+    }
+
+    @FXML
+    private void handleCancel() {
+        close();
+    }
+
+    @FXML
+    private void handleCopy() {
+        List<DTOProfiles> selected = new ArrayList<>();
+        profileMap.forEach((cb, profile) -> {
+            if (cb.isSelected()) {
+                selected.add(profile);
+            }
+        });
+        if (!selected.isEmpty()) {
+            actionController.copyTasksToProfiles(sourceProfile, selected);
+        }
+        close();
+    }
+
+    private void close() {
+        Stage stage = (Stage) lblSourceProfile.getScene().getWindow();
+        stage.close();
+    }
+}

--- a/wos-hmi/src/main/java/cl/camodev/wosbot/taskmanager/view/TaskManagerLayoutController.java
+++ b/wos-hmi/src/main/java/cl/camodev/wosbot/taskmanager/view/TaskManagerLayoutController.java
@@ -59,13 +59,16 @@ public class TaskManagerLayoutController {
 	@FXML
 	private TabPane tabPaneProfiles;
 
-	@FXML
-	private TextField txtFilterTaskName;
+        @FXML
+        private TextField txtFilterTaskName;
+
+        @FXML
+        private Button btnCopyTasks;
 
 	@FXML
-	public void initialize() {
-		loadProfiles();
-		setupFilterListener();
+        public void initialize() {
+                loadProfiles();
+                setupFilterListener();
 
 		Timeline ticker = new Timeline(new KeyFrame(Duration.seconds(1), evt -> updateTimeValues()));
 		ticker.setCycleCount(Animation.INDEFINITE);
@@ -80,18 +83,29 @@ public class TaskManagerLayoutController {
 		}
 	}
 
-	private void applyFilter(String filterText) {
-		String filter = filterText == null ? "" : filterText.toLowerCase().trim();
+        private void applyFilter(String filterText) {
+                String filter = filterText == null ? "" : filterText.toLowerCase().trim();
 
-		filteredTasks.forEach((profileId, filteredList) -> {
-			filteredList.setPredicate(task -> {
-				if (filter.isEmpty()) {
-					return true;
-				}
-				return task.getTaskName().toLowerCase().contains(filter);
-			});
-		});
-	}
+                filteredTasks.forEach((profileId, filteredList) -> {
+                        filteredList.setPredicate(task -> {
+                                if (filter.isEmpty()) {
+                                        return true;
+                                }
+                                return task.getTaskName().toLowerCase().contains(filter);
+                        });
+                });
+        }
+
+       @FXML
+       private void handleCopyTasks() {
+               Tab selected = tabPaneProfiles.getSelectionModel().getSelectedItem();
+               if (selected == null) {
+                       return;
+               }
+               Long profileId = (Long) selected.getUserData();
+               DTOProfiles profile = taskManagerActionController.findProfileById(profileId);
+               taskManagerActionController.showCopyTasksDialog(profile);
+       }
 
 	// Method to update time-dependent values and trigger reordering
 	private void updateTimeValues() {
@@ -201,9 +215,9 @@ public class TaskManagerLayoutController {
 	/**
 	 * Recarga el estado de las tareas y, cuando estén disponibles, construye la lista de TaskManagerAux y la entrega al consumidor.
 	 */
-	private void buildTaskManagerList(DTOProfiles profile, Consumer<List<TaskManagerAux>> onListReady) {
-		// Ahora `statuses` es una List<DTODailyTaskStatus>
-		taskManagerActionController.loadDailyTaskStatus(profile.getId(), (List<DTODailyTaskStatus> statuses) -> {
+        private void buildTaskManagerList(DTOProfiles profile, Consumer<List<TaskManagerAux>> onListReady) {
+                // Ahora `statuses` es una List<DTODailyTaskStatus>
+                taskManagerActionController.loadDailyTaskStatus(profile.getId(), (List<DTODailyTaskStatus> statuses) -> {
 			List<TaskManagerAux> list = Arrays.stream(TpDailyTaskEnum.values()).map(task -> {
 				// Busca el status cuyo ID coincida con el ID de la tarea
 //				System.out.println(">>> statuses.size=" + statuses.size() + "  buscando id=" + task.getId());
@@ -241,8 +255,23 @@ public class TaskManagerLayoutController {
 			}).collect(Collectors.toList());
 
 			Platform.runLater(() -> onListReady.accept(list));
-		});
-	}
+                });
+        }
+
+       public void refreshProfileTasks(Long profileId) {
+               DTOProfiles profile = taskManagerActionController.findProfileById(profileId);
+               if (profile == null) {
+                       return;
+               }
+               ObservableList<TaskManagerAux> dataList = tasks.get(profileId);
+               if (dataList == null) {
+                       return;
+               }
+               buildTaskManagerList(profile, list -> {
+                       dataList.setAll(list);
+                       FXCollections.sort(dataList, TASK_AUX_COMPARATOR);
+               });
+       }
 
 	private TableView<TaskManagerAux> createTaskTable() {
 		TableView<TaskManagerAux> table = new TableView<>();

--- a/wos-hmi/src/main/resources/cl/camodev/wosbot/taskmanager/view/CopyTasksDialog.fxml
+++ b/wos-hmi/src/main/resources/cl/camodev/wosbot/taskmanager/view/CopyTasksDialog.fxml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.CheckBox?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="cl.camodev.wosbot.taskmanager.view.CopyTasksDialogController">
+   <children>
+      <Label fx:id="lblSourceProfile" text="Source Profile" style="-fx-font-size: 16px; -fx-font-weight: bold;">
+         <VBox.margin>
+            <Insets bottom="10.0" left="20.0" right="20.0" top="20.0" />
+         </VBox.margin>
+      </Label>
+      <Label text="Select profiles to copy tasks to:" style="-fx-font-size: 12px;">
+         <VBox.margin>
+            <Insets bottom="10.0" left="20.0" right="20.0" />
+         </VBox.margin>
+      </Label>
+      <ScrollPane fitToWidth="true" prefHeight="300.0" prefWidth="400.0">
+         <VBox.margin>
+            <Insets left="20.0" right="20.0" />
+         </VBox.margin>
+         <content>
+            <VBox fx:id="vboxProfileList" spacing="5.0">
+               <padding>
+                  <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+               </padding>
+            </VBox>
+         </content>
+      </ScrollPane>
+      <HBox alignment="CENTER_RIGHT" spacing="10.0">
+         <VBox.margin>
+            <Insets bottom="20.0" left="20.0" right="20.0" top="20.0" />
+         </VBox.margin>
+         <children>
+            <Button fx:id="btnSelectAll" mnemonicParsing="false" onAction="#handleSelectAll" text="Select All" />
+            <Button fx:id="btnDeselectAll" mnemonicParsing="false" onAction="#handleDeselectAll" text="Deselect All" />
+            <Button fx:id="btnCancel" mnemonicParsing="false" onAction="#handleCancel" text="Cancel" />
+            <Button fx:id="btnCopy" mnemonicParsing="false" onAction="#handleCopy" style="-fx-background-color: #4CAF50; -fx-text-fill: white;" text="Copy" />
+         </children>
+      </HBox>
+   </children>
+</VBox>

--- a/wos-hmi/src/main/resources/cl/camodev/wosbot/taskmanager/view/TaskManagerLayout.fxml
+++ b/wos-hmi/src/main/resources/cl/camodev/wosbot/taskmanager/view/TaskManagerLayout.fxml
@@ -3,6 +3,7 @@
 <?import javafx.scene.control.TabPane?>
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.control.Label?>
+<?import javafx.scene.control.Button?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.geometry.Insets?>
@@ -15,6 +16,7 @@
             <Label text="Filter by name:" style="-fx-text-fill: white; -fx-font-size: 14px;" />
             <TextField fx:id="txtFilterTaskName" promptText="Enter task name..." prefWidth="250.0"
                       style="-fx-background-color: #404040; -fx-text-fill: white; -fx-prompt-text-fill: #AAAAAA;" />
+            <Button fx:id="btnCopyTasks" mnemonicParsing="false" onAction="#handleCopyTasks" text="Copy Tasks" />
          </children>
          <VBox.margin>
             <Insets />

--- a/wos-ot/src/main/java/cl/camodev/wosbot/ot/DTOConfig.java
+++ b/wos-ot/src/main/java/cl/camodev/wosbot/ot/DTOConfig.java
@@ -1,39 +1,39 @@
 package cl.camodev.wosbot.ot;
 
 public class DTOConfig {
-	private Long profileId; // Para saber a qué perfil pertenece
-	private String nombreConfiguracion;
-	private String valor;
+        private Long profileId; // profile identifier
+        private String key;
+        private String value;
 
-	public DTOConfig(Long profileId, String nombreConfiguracion, String valor) {
-		this.profileId = profileId;
-		this.nombreConfiguracion = nombreConfiguracion;
-		this.valor = valor;
-	}
+        public DTOConfig(Long profileId, String key, String value) {
+                this.profileId = profileId;
+                this.key = key;
+                this.value = value;
+        }
 
-	// Getters y Setters
+        // Getters and setters
 
-	public Long getProfileId() {
-		return profileId;
-	}
+        public Long getProfileId() {
+                return profileId;
+        }
 
-	public String getNombreConfiguracion() {
-		return nombreConfiguracion;
-	}
+        public String getKey() {
+                return key;
+        }
 
-	public String getValor() {
-		return valor;
-	}
+        public String getValue() {
+                return value;
+        }
 
-	public void setProfileId(Long profileId) {
-		this.profileId = profileId;
-	}
+        public void setProfileId(Long profileId) {
+                this.profileId = profileId;
+        }
 
-	public void setNombreConfiguracion(String nombreConfiguracion) {
-		this.nombreConfiguracion = nombreConfiguracion;
-	}
+        public void setKey(String key) {
+                this.key = key;
+        }
 
-	public void setValor(String valor) {
-		this.valor = valor;
-	}
+        public void setValue(String value) {
+                this.value = value;
+        }
 }

--- a/wos-ot/src/main/java/cl/camodev/wosbot/ot/DTOProfiles.java
+++ b/wos-ot/src/main/java/cl/camodev/wosbot/ot/DTOProfiles.java
@@ -79,34 +79,34 @@ public class DTOProfiles {
 
 	}
 
-	/**
-	 * Obtiene el valor de una configuración específica utilizando EnumConfigurationKey. Es un método genérico que devuelve el tipo correcto
-	 * basado en la clave.
-	 */
-	public <T> T getConfig(EnumConfigurationKey key, Class<T> clazz) {
-		Optional<DTOConfig> configOptional = configs.stream().filter(config -> config.getNombreConfiguracion().equalsIgnoreCase(key.name())).findFirst();
+        /**
+         * Retrieves the value for a specific configuration using {@link EnumConfigurationKey}.
+         * This generic method returns the correct type based on the key.
+         */
+        public <T> T getConfig(EnumConfigurationKey key, Class<T> clazz) {
+                Optional<DTOConfig> configOptional = configs.stream().filter(config -> config.getKey().equalsIgnoreCase(key.name())).findFirst();
 
-		if (!configOptional.isPresent()) {
+                if (!configOptional.isPresent()) {
 
-			DTOConfig defaultConfig = new DTOConfig(-1L, key.name(), key.getDefaultValue());
-			configs.add(defaultConfig);
-		}
-		String valor = configOptional.map(DTOConfig::getValor).orElse(key.getDefaultValue());
+                        DTOConfig defaultConfig = new DTOConfig(-1L, key.name(), key.getDefaultValue());
+                        configs.add(defaultConfig);
+                }
+                String value = configOptional.map(DTOConfig::getValue).orElse(key.getDefaultValue());
 
-		return key.castValue(valor);
-	}
+                return key.castValue(value);
+        }
 
-	public <T> void setConfig(EnumConfigurationKey key, T value) {
-		String valorAAlmacenar = value.toString();
-		Optional<DTOConfig> configOptional = configs.stream().filter(config -> config.getNombreConfiguracion().equalsIgnoreCase(key.name())).findFirst();
+        public <T> void setConfig(EnumConfigurationKey key, T value) {
+                String valueToStore = value.toString();
+                Optional<DTOConfig> configOptional = configs.stream().filter(config -> config.getKey().equalsIgnoreCase(key.name())).findFirst();
 
-		if (configOptional.isPresent()) {
-			configOptional.get().setValor(valorAAlmacenar);
-		} else {
-			DTOConfig nuevaConfig = new DTOConfig(getId(), key.name(), valorAAlmacenar);
-			configs.add(nuevaConfig);
-		}
-	}
+                if (configOptional.isPresent()) {
+                        configOptional.get().setValue(valueToStore);
+                } else {
+                        DTOConfig newConfig = new DTOConfig(getId(), key.name(), valueToStore);
+                        configs.add(newConfig);
+                }
+        }
 
 	public String getStatus() {
 		return status;

--- a/wos-persistence/pom.xml
+++ b/wos-persistence/pom.xml
@@ -29,11 +29,17 @@
 			<version>6.2.7.Final</version>
 		</dependency>
 
-		<dependency>
-			<groupId>com.zaxxer</groupId>
-			<artifactId>HikariCP</artifactId>
-			<version>5.0.1</version> <!-- Ajusta la versión según tus necesidades -->
-		</dependency>
+                <dependency>
+                        <groupId>com.zaxxer</groupId>
+                        <artifactId>HikariCP</artifactId>
+                        <version>5.0.1</version> <!-- Ajusta la versión según tus necesidades -->
+                </dependency>
+
+                <dependency>
+                        <groupId>org.hibernate.orm</groupId>
+                        <artifactId>hibernate-hikaricp</artifactId>
+                        <version>6.2.7.Final</version>
+                </dependency>
 
 
 		<!-- API de JPA -->

--- a/wos-persistence/src/main/java/cl/camodev/wosbot/almac/entity/Config.java
+++ b/wos-persistence/src/main/java/cl/camodev/wosbot/almac/entity/Config.java
@@ -35,18 +35,18 @@ public class Config {
 	@Column(name = "config_key", nullable = false)
 	private String key;
 
-	@Column(name = "value", nullable = false)
-	private String valor;
+        @Column(name = "value", nullable = false)
+        private String value;
 
 	public Config() {
 	}
 
-	public Config(Profile profile, TpConfig tpConfig, String key, String valor) {
-		this.profile = profile;
-		this.tpConfig = tpConfig;
-		this.key = key;
-		this.valor = valor;
-	}
+        public Config(Profile profile, TpConfig tpConfig, String key, String value) {
+                this.profile = profile;
+                this.tpConfig = tpConfig;
+                this.key = key;
+                this.value = value;
+        }
 
 	// Getters y Setters
 	public Integer getId() {
@@ -81,16 +81,16 @@ public class Config {
 		this.key = key;
 	}
 
-	public String getValor() {
-		return valor;
-	}
+        public String getValue() {
+                return value;
+        }
 
-	public void setValor(String valor) {
-		this.valor = valor;
-	}
+        public void setValue(String value) {
+                this.value = value;
+        }
 
 	@Override
 	public String toString() {
-		return "Config{" + "id=" + id + ", profile=" + (profile != null ? profile.getId() : "Global") + ", tpConfig=" + tpConfig.getName() + ", key='" + key + '\'' + ", valor='" + valor + '\'' + '}';
-	}
+                return "Config{" + "id=" + id + ", profile=" + (profile != null ? profile.getId() : "Global") + ", tpConfig=" + tpConfig.getName() + ", key='" + key + '\'' + ", value='" + value + '\'' + '}';
+        }
 }

--- a/wos-persistence/src/main/java/cl/camodev/wosbot/almac/jpa/BotPersistence.java
+++ b/wos-persistence/src/main/java/cl/camodev/wosbot/almac/jpa/BotPersistence.java
@@ -40,8 +40,9 @@ public final class BotPersistence {
                 try {
                         Map<String, Object> properties = new HashMap<>();
                         properties.put(JDBC_URL_PROPERTY, SQLITE_PREFIX + resolveDatabasePath(profile));
-                        properties.put(HIKARI_MINIMUM_IDLE, SQLITE_POOL_SIZE);
-                        properties.put(HIKARI_MAXIMUM_POOL_SIZE, SQLITE_POOL_SIZE);
+                        // Hikari expects configuration values as Strings
+                        properties.put(HIKARI_MINIMUM_IDLE, String.valueOf(SQLITE_POOL_SIZE));
+                        properties.put(HIKARI_MAXIMUM_POOL_SIZE, String.valueOf(SQLITE_POOL_SIZE));
                         entityManagerFactory =
                                         Persistence.createEntityManagerFactory(PERSISTENCE_UNIT_NAME, properties);
                         configureSQLite();

--- a/wos-persistence/src/main/java/cl/camodev/wosbot/almac/jpa/BotPersistence.java
+++ b/wos-persistence/src/main/java/cl/camodev/wosbot/almac/jpa/BotPersistence.java
@@ -27,6 +27,10 @@ public final class BotPersistence {
         private static final String SQLITE_PREFIX = "jdbc:sqlite:";
         private static final String PRAGMA_JOURNAL_MODE_WAL = "PRAGMA journal_mode=WAL";
         private static final String PRAGMA_SYNC_NORMAL = "PRAGMA synchronous=NORMAL";
+        private static final String PRAGMA_BUSY_TIMEOUT = "PRAGMA busy_timeout=5000";
+        private static final String HIKARI_MINIMUM_IDLE = "hibernate.hikari.minimumIdle";
+        private static final String HIKARI_MAXIMUM_POOL_SIZE = "hibernate.hikari.maximumPoolSize";
+        private static final int SQLITE_POOL_SIZE = 1;
         private static final Map<String, BotPersistence> INSTANCES = new ConcurrentHashMap<>();
         private final EntityManagerFactory entityManagerFactory;
         private final String profile;
@@ -36,6 +40,8 @@ public final class BotPersistence {
                 try {
                         Map<String, Object> properties = new HashMap<>();
                         properties.put(JDBC_URL_PROPERTY, SQLITE_PREFIX + resolveDatabasePath(profile));
+                        properties.put(HIKARI_MINIMUM_IDLE, SQLITE_POOL_SIZE);
+                        properties.put(HIKARI_MAXIMUM_POOL_SIZE, SQLITE_POOL_SIZE);
                         entityManagerFactory =
                                         Persistence.createEntityManagerFactory(PERSISTENCE_UNIT_NAME, properties);
                         configureSQLite();
@@ -68,6 +74,7 @@ public final class BotPersistence {
                                 try (Statement statement = connection.createStatement()) {
                                         statement.execute(PRAGMA_JOURNAL_MODE_WAL);
                                         statement.execute(PRAGMA_SYNC_NORMAL);
+                                        statement.execute(PRAGMA_BUSY_TIMEOUT);
                                 }
                         });
                 } catch (Exception e) {

--- a/wos-persistence/src/main/java/cl/camodev/wosbot/almac/jpa/BotPersistence.java
+++ b/wos-persistence/src/main/java/cl/camodev/wosbot/almac/jpa/BotPersistence.java
@@ -7,6 +7,10 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.sql.Statement;
+
+import org.hibernate.Session;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
@@ -23,17 +27,19 @@ public final class BotPersistence {
         private static final String SQLITE_PREFIX = "jdbc:sqlite:";
         private static final String PRAGMA_JOURNAL_MODE_WAL = "PRAGMA journal_mode=WAL";
         private static final String PRAGMA_SYNC_NORMAL = "PRAGMA synchronous=NORMAL";
-        private static BotPersistence instance;
-        private static EntityManagerFactory entityManagerFactory;
+        private static final Map<String, BotPersistence> INSTANCES = new ConcurrentHashMap<>();
+        private final EntityManagerFactory entityManagerFactory;
+        private final String profile;
 
-        private BotPersistence() {
+        private BotPersistence(String profile) {
+                this.profile = profile;
                 try {
                         Map<String, Object> properties = new HashMap<>();
-                        properties.put(JDBC_URL_PROPERTY, SQLITE_PREFIX + resolveDatabasePath());
+                        properties.put(JDBC_URL_PROPERTY, SQLITE_PREFIX + resolveDatabasePath(profile));
                         entityManagerFactory =
                                         Persistence.createEntityManagerFactory(PERSISTENCE_UNIT_NAME, properties);
                         configureSQLite();
-                        PersistenceDataInitialization.initializeData();
+                        PersistenceDataInitialization.initializeData(this);
                 } catch (Exception ex) {
                         System.err.println("Error inicializando EntityManagerFactory: " + ex.getMessage());
                         throw new ExceptionInInitializerError(ex);
@@ -41,18 +47,15 @@ public final class BotPersistence {
         }
 
         public static BotPersistence getInstance() {
-                if (instance == null) {
-                        synchronized (BotPersistence.class) {
-                                if (instance == null) {
-                                        instance = new BotPersistence();
-                                }
-                        }
-                }
-                return instance;
+                String profile = System.getProperty(PROFILE_PROPERTY, DEFAULT_PROFILE);
+                return getInstance(profile);
         }
 
-        private static String resolveDatabasePath() throws IOException {
-                String profile = System.getProperty(PROFILE_PROPERTY, DEFAULT_PROFILE);
+        public static BotPersistence getInstance(String profile) {
+                return INSTANCES.computeIfAbsent(profile, BotPersistence::new);
+        }
+
+        private static String resolveDatabasePath(String profile) throws IOException {
                 Path directory = Paths.get(DB_FOLDER);
                 Files.createDirectories(directory);
                 return directory.resolve(profile + ".db").toString();
@@ -61,23 +64,22 @@ public final class BotPersistence {
         private void configureSQLite() {
                 EntityManager entityManager = getEntityManager();
                 try {
-                        entityManager.getTransaction().begin();
-                        entityManager.createNativeQuery(PRAGMA_JOURNAL_MODE_WAL).executeUpdate();
-                        entityManager.createNativeQuery(PRAGMA_SYNC_NORMAL).executeUpdate();
-                        entityManager.getTransaction().commit();
+                        entityManager.unwrap(Session.class).doWork(connection -> {
+                                try (Statement statement = connection.createStatement()) {
+                                        statement.execute(PRAGMA_JOURNAL_MODE_WAL);
+                                        statement.execute(PRAGMA_SYNC_NORMAL);
+                                }
+                        });
                 } catch (Exception e) {
                         System.err.println("Error configuring SQLite: " + e.getMessage());
-                        if (entityManager.getTransaction().isActive()) {
-                                entityManager.getTransaction().rollback();
-                        }
                 } finally {
                         entityManager.close();
                 }
         }
 
-	private EntityManager getEntityManager() {
-		return entityManagerFactory.createEntityManager();
-	}
+        private EntityManager getEntityManager() {
+                return entityManagerFactory.createEntityManager();
+        }
 
 	public boolean createEntity(Object entity) {
 		EntityManager entityManager = getEntityManager();

--- a/wos-persistence/src/main/java/cl/camodev/wosbot/almac/jpa/PersistenceDataInitialization.java
+++ b/wos-persistence/src/main/java/cl/camodev/wosbot/almac/jpa/PersistenceDataInitialization.java
@@ -6,27 +6,23 @@ import cl.camodev.wosbot.console.enumerable.TpConfigEnum;
 import cl.camodev.wosbot.console.enumerable.TpDailyTaskEnum;
 
 public class PersistenceDataInitialization {
-	private static boolean initialized = false; // Asegura que solo se ejecute una vez
 
-	public static void initializeData() {
-		if (initialized)
-			return;
-		initialized = true;
+        private PersistenceDataInitialization() {
+        }
 
-		BotPersistence persistence = BotPersistence.getInstance();
+        public static void initializeData(BotPersistence persistence) {
+                for (TpDailyTaskEnum taskEnum : TpDailyTaskEnum.values()) {
+                        TpDailyTask existingTask = persistence.findEntityById(TpDailyTask.class, taskEnum.getId());
+                        if (existingTask == null) {
+                                persistence.createEntity(new TpDailyTask(taskEnum));
+                        }
+                }
 
-		for (TpDailyTaskEnum taskEnum : TpDailyTaskEnum.values()) {
-			TpDailyTask existingTask = persistence.findEntityById(TpDailyTask.class, taskEnum.getId());
-			if (existingTask == null) {
-				persistence.createEntity(new TpDailyTask(taskEnum));
-			}
-		}
-
-		for (TpConfigEnum tpConfigEnum : TpConfigEnum.values()) {
-			TpConfig existingTpConfig = persistence.findEntityById(TpConfig.class, tpConfigEnum.getId());
-			if (existingTpConfig == null) {
-				persistence.createEntity(new TpConfig(tpConfigEnum));
-			}
-		}
-	}
+                for (TpConfigEnum tpConfigEnum : TpConfigEnum.values()) {
+                        TpConfig existingTpConfig = persistence.findEntityById(TpConfig.class, tpConfigEnum.getId());
+                        if (existingTpConfig == null) {
+                                persistence.createEntity(new TpConfig(tpConfigEnum));
+                        }
+                }
+        }
 }

--- a/wos-persistence/src/main/java/cl/camodev/wosbot/almac/repo/ConfigRepository.java
+++ b/wos-persistence/src/main/java/cl/camodev/wosbot/almac/repo/ConfigRepository.java
@@ -6,58 +6,67 @@ import java.util.Map;
 
 import cl.camodev.wosbot.almac.entity.Config;
 import cl.camodev.wosbot.almac.entity.TpConfig;
-import cl.camodev.wosbot.almac.jpa.BotPersistence;
 import cl.camodev.wosbot.console.enumerable.TpConfigEnum;
 
+import cl.camodev.wosbot.almac.jpa.BotPersistence;
+
 public class ConfigRepository implements IConfigRepository {
-	private final BotPersistence persistence = BotPersistence.getInstance();
+        private static ConfigRepository instance;
 
-	private static ConfigRepository instance;
+        public static ConfigRepository getRepository() {
+                if (instance == null) {
+                        instance = new ConfigRepository();
+                }
+                return instance;
+        }
 
-	public static ConfigRepository getRepository() {
-		if (instance == null) {
-			instance = new ConfigRepository();
-		}
-		return instance;
-	}
+        private BotPersistence getPersistence(Long profileId) {
+                return BotPersistence.getInstance(String.valueOf(profileId));
+        }
 
 	@Override
 	public boolean addConfig(Config config) {
-		return persistence.createEntity(config);
+                Long profileId = config.getProfile() != null ? config.getProfile().getId() : null;
+                BotPersistence persistence = profileId != null ? getPersistence(profileId) : BotPersistence.getInstance();
+                return persistence.createEntity(config);
 	}
 
 	@Override
 	public boolean saveConfig(Config config) {
-		return persistence.updateEntity(config);
+                Long profileId = config.getProfile() != null ? config.getProfile().getId() : null;
+                BotPersistence persistence = profileId != null ? getPersistence(profileId) : BotPersistence.getInstance();
+                return persistence.updateEntity(config);
 	}
 
 	@Override
 	public boolean deleteConfig(Config config) {
-		return persistence.deleteEntity(config);
+                Long profileId = config.getProfile() != null ? config.getProfile().getId() : null;
+                BotPersistence persistence = profileId != null ? getPersistence(profileId) : BotPersistence.getInstance();
+                return persistence.deleteEntity(config);
 	}
 
-	@Override
-	public Config getConfigById(Long id) {
-		return persistence.findEntityById(Config.class, id);
-	}
+        @Override
+        public Config getConfigById(Long profileId, Long id) {
+                return getPersistence(profileId).findEntityById(Config.class, id);
+        }
 
 	@Override
 	public List<Config> getProfileConfigs(Long profileId) {
 		String query = "SELECT c FROM Config c WHERE c.profile.id = :profileId";
 		Map<String, Object> parameters = new HashMap<>();
 		parameters.put("profileId", profileId);
-		return persistence.getQueryResults(query, Config.class, parameters);
+                return getPersistence(profileId).getQueryResults(query, Config.class, parameters);
 	}
 
 	@Override
 	public List<Config> getGlobalConfigs() {
 		String query = "SELECT c FROM Config c WHERE c.profile IS NULL";
-		return persistence.getQueryResults(query, Config.class, null);
+                return BotPersistence.getInstance().getQueryResults(query, Config.class, null);
 	}
 
 	@Override
 	public TpConfig getTpConfig(TpConfigEnum tpConfigEnum) {
-		return persistence.findEntityById(TpConfig.class, tpConfigEnum.getId());
-	}
+                return BotPersistence.getInstance().findEntityById(TpConfig.class, tpConfigEnum.getId());
+}
 
 }

--- a/wos-persistence/src/main/java/cl/camodev/wosbot/almac/repo/DailyTaskRepository.java
+++ b/wos-persistence/src/main/java/cl/camodev/wosbot/almac/repo/DailyTaskRepository.java
@@ -7,43 +7,50 @@ import java.util.stream.Collectors;
 
 import cl.camodev.wosbot.almac.entity.DailyTask;
 import cl.camodev.wosbot.almac.entity.TpDailyTask;
-import cl.camodev.wosbot.almac.jpa.BotPersistence;
 import cl.camodev.wosbot.console.enumerable.TpDailyTaskEnum;
 import cl.camodev.wosbot.ot.DTODailyTaskStatus;
 
+import cl.camodev.wosbot.almac.jpa.BotPersistence;
+
 public class DailyTaskRepository implements IDailyTaskRepository {
-	private final BotPersistence persistence = BotPersistence.getInstance();
+        private static DailyTaskRepository instance;
 
-	private static DailyTaskRepository instance;
+        private DailyTaskRepository() {
+        }
 
-	private DailyTaskRepository() {
-	}
+        public static DailyTaskRepository getRepository() {
+                if (instance == null) {
+                        instance = new DailyTaskRepository();
+                }
+                return instance;
+        }
 
-	public static DailyTaskRepository getRepository() {
-		if (instance == null) {
-			instance = new DailyTaskRepository();
-		}
-		return instance;
-	}
+        private BotPersistence getPersistence(Long profileId) {
+                return BotPersistence.getInstance(String.valueOf(profileId));
+        }
 
 	@Override
 	public boolean addDailyTask(DailyTask dailyTask) {
-		return persistence.createEntity(dailyTask);
+                Long profileId = dailyTask.getProfile().getId();
+                return getPersistence(profileId).createEntity(dailyTask);
 	}
 
 	@Override
 	public boolean saveDailyTask(DailyTask dailyTask) {
-		return persistence.updateEntity(dailyTask);
+                Long profileId = dailyTask.getProfile().getId();
+                return getPersistence(profileId).updateEntity(dailyTask);
 	}
 
 	@Override
 	public boolean deleteDailyTask(DailyTask dailyTask) {
-		return persistence.deleteEntity(dailyTask);
+                Long profileId = dailyTask.getProfile().getId();
+                return getPersistence(profileId).deleteEntity(dailyTask);
 	}
 
 	@Override
 	public DailyTask getDailyTaskById(Long id) {
-		return persistence.findEntityById(DailyTask.class, id);
+                // Profile-specific lookup requires profileId; default to global instance
+                return BotPersistence.getInstance().findEntityById(DailyTask.class, id);
 	}
 
 	@Override
@@ -54,7 +61,7 @@ public class DailyTaskRepository implements IDailyTaskRepository {
 		Map<String, Object> parameters = new HashMap<>();
 		parameters.put("profileId", profileId);
 
-		return persistence.getQueryResults(query, DailyTask.class, parameters);
+                return getPersistence(profileId).getQueryResults(query, DailyTask.class, parameters);
 	}
 
 	@Override
@@ -68,7 +75,7 @@ public class DailyTaskRepository implements IDailyTaskRepository {
 		parameters.put("profileId", profileId);
 		parameters.put("id", taskName.getId());
 
-		List<DailyTask> results = persistence.getQueryResults(query, DailyTask.class, parameters);
+                List<DailyTask> results = getPersistence(profileId).getQueryResults(query, DailyTask.class, parameters);
 
 		return results.isEmpty() ? null : results.get(0);
 	}
@@ -85,13 +92,13 @@ public class DailyTaskRepository implements IDailyTaskRepository {
 		Map<String, Object> parameters = new HashMap<>();
 		parameters.put("profileId", profileId);
 
-		List<DTODailyTaskStatus> results = persistence.getQueryResults(query, DTODailyTaskStatus.class, parameters);
+                List<DTODailyTaskStatus> results = getPersistence(profileId).getQueryResults(query, DTODailyTaskStatus.class, parameters);
 
 		return results.stream().collect(Collectors.toMap(DTODailyTaskStatus::getIdTpDailyTask, dto -> dto));
 	}
 
 	@Override
 	public TpDailyTask findTpDailyTaskById(Integer id) {
-		return persistence.findEntityById(TpDailyTask.class, id);
-	}
+                return BotPersistence.getInstance().findEntityById(TpDailyTask.class, id);
+}
 }

--- a/wos-persistence/src/main/java/cl/camodev/wosbot/almac/repo/DailyTaskRepository.java
+++ b/wos-persistence/src/main/java/cl/camodev/wosbot/almac/repo/DailyTaskRepository.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import cl.camodev.wosbot.almac.entity.DailyTask;
+import cl.camodev.wosbot.almac.entity.Profile;
 import cl.camodev.wosbot.almac.entity.TpDailyTask;
 import cl.camodev.wosbot.console.enumerable.TpDailyTaskEnum;
 import cl.camodev.wosbot.ot.DTODailyTaskStatus;
@@ -14,6 +15,8 @@ import cl.camodev.wosbot.almac.jpa.BotPersistence;
 
 public class DailyTaskRepository implements IDailyTaskRepository {
         private static DailyTaskRepository instance;
+
+        private final BotPersistence defaultPersistence = BotPersistence.getInstance();
 
         private DailyTaskRepository() {
         }
@@ -27,6 +30,37 @@ public class DailyTaskRepository implements IDailyTaskRepository {
 
         private BotPersistence getPersistence(Long profileId) {
                 return BotPersistence.getInstance(String.valueOf(profileId));
+        }
+
+        private void migrateLegacyTasks(Long profileId) {
+                String query = "SELECT d FROM DailyTask d WHERE d.profile.id = :profileId";
+                Map<String, Object> params = new HashMap<>();
+                params.put("profileId", profileId);
+
+                List<DailyTask> legacy = defaultPersistence.getQueryResults(query, DailyTask.class, params);
+                if (legacy == null || legacy.isEmpty()) {
+                        return;
+                }
+
+                Profile sourceProfile = defaultPersistence.findEntityById(Profile.class, profileId);
+                if (sourceProfile == null) {
+                        return;
+                }
+
+                Profile profileCopy = new Profile();
+                profileCopy.setId(sourceProfile.getId());
+                profileCopy.setName(sourceProfile.getName());
+                profileCopy.setEmulatorNumber(sourceProfile.getEmulatorNumber());
+                profileCopy.setEnabled(sourceProfile.getEnabled());
+
+                BotPersistence target = getPersistence(profileId);
+                target.updateEntity(profileCopy);
+
+                for (DailyTask task : legacy) {
+                        DailyTask copy = new DailyTask(profileCopy, task.getTask(), task.getLastExecution(), task.getNextSchedule());
+                        target.createEntity(copy);
+                        defaultPersistence.deleteEntity(task);
+                }
         }
 
 	@Override
@@ -54,15 +88,16 @@ public class DailyTaskRepository implements IDailyTaskRepository {
 	}
 
 	@Override
-	public List<DailyTask> findByProfileId(Long profileId) {
-		String query = "SELECT d FROM DailyTask d WHERE d.profile.id = :profileId";
+        public List<DailyTask> findByProfileId(Long profileId) {
+                migrateLegacyTasks(profileId);
 
-		// Crear el mapa de parámetros
-		Map<String, Object> parameters = new HashMap<>();
-		parameters.put("profileId", profileId);
+                String query = "SELECT d FROM DailyTask d WHERE d.profile.id = :profileId";
+
+                Map<String, Object> parameters = new HashMap<>();
+                parameters.put("profileId", profileId);
 
                 return getPersistence(profileId).getQueryResults(query, DailyTask.class, parameters);
-	}
+        }
 
 	@Override
 	public DailyTask findByProfileIdAndTaskName(Long profileId, TpDailyTaskEnum taskName) {
@@ -81,21 +116,22 @@ public class DailyTaskRepository implements IDailyTaskRepository {
 	}
 
 	@Override
-	public Map<Integer, DTODailyTaskStatus> findDailyTasksStatusByProfile(Long profileId) {
-		String query = """
-				SELECT new cl.camodev.wosbot.ot.DTODailyTaskStatus(
-				d.profile.id, d.task.id, d.lastExecution, d.nextSchedule)
-				FROM DailyTask d
-				WHERE d.profile.id = :profileId""";
+        public Map<Integer, DTODailyTaskStatus> findDailyTasksStatusByProfile(Long profileId) {
+                migrateLegacyTasks(profileId);
 
-		// Crear el mapa de parámetros
-		Map<String, Object> parameters = new HashMap<>();
-		parameters.put("profileId", profileId);
+                String query = """
+                                SELECT new cl.camodev.wosbot.ot.DTODailyTaskStatus(
+                                d.profile.id, d.task.id, d.lastExecution, d.nextSchedule)
+                                FROM DailyTask d
+                                WHERE d.profile.id = :profileId""";
+
+                Map<String, Object> parameters = new HashMap<>();
+                parameters.put("profileId", profileId);
 
                 List<DTODailyTaskStatus> results = getPersistence(profileId).getQueryResults(query, DTODailyTaskStatus.class, parameters);
 
-		return results.stream().collect(Collectors.toMap(DTODailyTaskStatus::getIdTpDailyTask, dto -> dto));
-	}
+                return results.stream().collect(Collectors.toMap(DTODailyTaskStatus::getIdTpDailyTask, dto -> dto));
+        }
 
 	@Override
 	public TpDailyTask findTpDailyTaskById(Integer id) {

--- a/wos-persistence/src/main/java/cl/camodev/wosbot/almac/repo/IConfigRepository.java
+++ b/wos-persistence/src/main/java/cl/camodev/wosbot/almac/repo/IConfigRepository.java
@@ -15,7 +15,7 @@ public interface IConfigRepository {
 
 	boolean deleteConfig(Config config);
 
-	Config getConfigById(Long id);
+        Config getConfigById(Long profileId, Long id);
 
 	List<Config> getProfileConfigs(Long profileId);
 

--- a/wos-persistence/src/main/java/cl/camodev/wosbot/almac/repo/ProfileRepository.java
+++ b/wos-persistence/src/main/java/cl/camodev/wosbot/almac/repo/ProfileRepository.java
@@ -53,7 +53,7 @@ public class ProfileRepository implements IProfileRepository {
 
 		if (!profileIds.isEmpty()) {
 			// Consulta para obtener las configuraciones de los perfiles
-			String queryConfigs = "SELECT new cl.camodev.wosbot.ot.DTOConfig(c.profile.id, c.key, c.valor) " + "FROM Config c WHERE c.profile.id IN :profileIds";
+                        String queryConfigs = "SELECT new cl.camodev.wosbot.ot.DTOConfig(c.profile.id, c.key, c.value) " + "FROM Config c WHERE c.profile.id IN :profileIds";
 
 			// Pasar parámetros a la consulta
 			Map<String, Object> parameters = new HashMap<>();

--- a/wos-persistence/src/main/resources/META-INF/persistence.xml
+++ b/wos-persistence/src/main/resources/META-INF/persistence.xml
@@ -14,8 +14,8 @@
 			<property name="hibernate.hbm2ddl.auto" value="update" />
 			<!-- <property name="hibernate.show_sql" value="true" /> -->
 			<!-- <property name="hibernate.format_sql" value="true" /> -->
-			<property name="hibernate.connection.provider_class"
-				value="com.zaxxer.hikari.hibernate.HikariConnectionProvider" />
+                        <property name="hibernate.connection.provider_class"
+                                value="org.hibernate.hikaricp.internal.HikariCPConnectionProvider" />
 			<property name="hibernate.hikari.minimumIdle" value="5" />
 			<property name="hibernate.hikari.maximumPoolSize" value="20" />
 			<property name="hibernate.hikari.idleTimeout" value="300000" />

--- a/wos-persistence/src/main/resources/META-INF/persistence.xml
+++ b/wos-persistence/src/main/resources/META-INF/persistence.xml
@@ -16,8 +16,8 @@
 			<!-- <property name="hibernate.format_sql" value="true" /> -->
                         <property name="hibernate.connection.provider_class"
                                 value="org.hibernate.hikaricp.internal.HikariCPConnectionProvider" />
-			<property name="hibernate.hikari.minimumIdle" value="5" />
-			<property name="hibernate.hikari.maximumPoolSize" value="20" />
+                        <property name="hibernate.hikari.minimumIdle" value="1" />
+                        <property name="hibernate.hikari.maximumPoolSize" value="1" />
 			<property name="hibernate.hikari.idleTimeout" value="300000" />
 		</properties>
 	</persistence-unit>

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServConfig.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServConfig.java
@@ -31,10 +31,10 @@ public class ServConfig {
 			return null;
 		}
 
-		HashMap<String, String> globalConfig = new HashMap<>();
-		for (Config config : configs) {
-			globalConfig.put(config.getKey(), config.getValor());
-		}
+                HashMap<String, String> globalConfig = new HashMap<>();
+                for (Config config : configs) {
+                        globalConfig.put(config.getKey(), config.getValue());
+                }
 		return globalConfig;
 	}
 

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServProfiles.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServProfiles.java
@@ -52,9 +52,9 @@ public class ServProfiles implements IServProfile {
 		List<Config> configs = iConfigRepository.getGlobalConfigs();
 		if (configs != null) {
 			HashMap<EnumConfigurationKey, String> settings = new HashMap<EnumConfigurationKey, String>();
-			for (Config config : configs) {
-				settings.put(EnumConfigurationKey.valueOf(config.getKey()), config.getValor());
-			}
+                        for (Config config : configs) {
+                                settings.put(EnumConfigurationKey.valueOf(config.getKey()), config.getValue());
+                        }
 			return settings;
 		} else {
 			return null;
@@ -114,7 +114,7 @@ public class ServProfiles implements IServProfile {
 				return false;
 			}
 
-			List<Config> newConfigs = profileDTO.getConfigs().stream().map(dtoConfig -> new Config(existingProfile, tpConfig, dtoConfig.getNombreConfiguracion(), dtoConfig.getValor())).collect(Collectors.toList());
+                        List<Config> newConfigs = profileDTO.getConfigs().stream().map(dtoConfig -> new Config(existingProfile, tpConfig, dtoConfig.getKey(), dtoConfig.getValue())).collect(Collectors.toList());
 
 			newConfigs.forEach(config -> iConfigRepository.addConfig(config));
 

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServScheduler.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServScheduler.java
@@ -110,38 +110,40 @@ public class ServScheduler {
 				// obtain current task schedules
 				Map<Integer, DTODailyTaskStatus> taskSchedules = iDailyTaskRepository.findDailyTasksStatusByProfile(profile.getId());
 
-				// Enqueue tasks based on profile configuration
-				taskMappings.forEach((configKey, suppliers) -> {
-					if (profile.getConfig(configKey, Boolean.class)) {
-						for (Supplier<DelayedTask> sup : suppliers) {
-							DelayedTask task = sup.get();
+                               // Enqueue tasks based on profile configuration or existing schedules
+                               taskMappings.forEach((configKey, suppliers) -> {
+                                       for (Supplier<DelayedTask> sup : suppliers) {
+                                               DelayedTask task = sup.get();
+                                               boolean enabled = profile.getConfig(configKey, Boolean.class)
+                                                               || taskSchedules.containsKey(task.getTpDailyTaskId());
+                                               if (!enabled) {
+                                                       continue;
+                                               }
 
-							// Construir estado y encolar
-							DTOTaskState taskState = new DTOTaskState();
-							taskState.setProfileId(profile.getId());
-							taskState.setTaskId(task.getTpTask().getId());
-							taskState.setExecuting(false);
-							taskState.setScheduled(true);
+                                               DTOTaskState taskState = new DTOTaskState();
+                                               taskState.setProfileId(profile.getId());
+                                               taskState.setTaskId(task.getTpTask().getId());
+                                               taskState.setExecuting(false);
+                                               taskState.setScheduled(true);
 
-							DTODailyTaskStatus status = taskSchedules.get(task.getTpDailyTaskId());
-							if (status != null) {
-								LocalDateTime next = status.getNextSchedule();
-								task.reschedule(next);
-								taskState.setLastExecutionTime(status.getLastExecution());
-								taskState.setNextExecutionTime(next);
-								ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, task.getTaskName(), profile.getName(), "Next Execution: " + next.format(fmt));
-							} else {
-								task.reschedule(LocalDateTime.now());
-								taskState.setLastExecutionTime(null);
-								taskState.setNextExecutionTime(task.getScheduled());
-								ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, task.getTaskName(), profile.getName(), "Task not completed, scheduling for today");
-							}
+                                               DTODailyTaskStatus status = taskSchedules.get(task.getTpDailyTaskId());
+                                               if (status != null) {
+                                                       LocalDateTime next = status.getNextSchedule();
+                                                       task.reschedule(next);
+                                                       taskState.setLastExecutionTime(status.getLastExecution());
+                                                       taskState.setNextExecutionTime(next);
+                                                       ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, task.getTaskName(), profile.getName(), "Next Execution: " + next.format(fmt));
+                                               } else {
+                                                       task.reschedule(LocalDateTime.now());
+                                                       taskState.setLastExecutionTime(null);
+                                                       taskState.setNextExecutionTime(task.getScheduled());
+                                                       ServLogs.getServices().appendLog(EnumTpMessageSeverity.INFO, task.getTaskName(), profile.getName(), "Task not completed, scheduling for today");
+                                               }
 
-							ServTaskManager.getInstance().setTaskState(profile.getId(), taskState);
-							queue.addTask(task);
-						}
-					}
-				});
+                                               ServTaskManager.getInstance().setTaskState(profile.getId(), taskState);
+                                               queue.addTask(task);
+                                       }
+                               });
 			});
 
 			queueManager.startQueues();

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServScheduler.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServScheduler.java
@@ -16,6 +16,7 @@ import cl.camodev.wosbot.almac.entity.DailyTask;
 import cl.camodev.wosbot.almac.entity.Profile;
 import cl.camodev.wosbot.almac.entity.TpConfig;
 import cl.camodev.wosbot.almac.entity.TpDailyTask;
+import cl.camodev.wosbot.almac.jpa.BotPersistence;
 import cl.camodev.wosbot.almac.repo.ConfigRepository;
 import cl.camodev.wosbot.almac.repo.DailyTaskRepository;
 import cl.camodev.wosbot.almac.repo.IConfigRepository;
@@ -287,10 +288,21 @@ public class ServScheduler {
                                return false;
                        }
                        for (Long targetId : targetProfileIds) {
-                               Profile targetProfile = iProfileRepository.getProfileById(targetId);
+                               BotPersistence targetPersistence = BotPersistence.getInstance(String.valueOf(targetId));
+                               Profile targetProfile = targetPersistence.findEntityById(Profile.class, targetId);
                                if (targetProfile == null) {
-                                       continue;
+                                       Profile baseProfile = iProfileRepository.getProfileById(targetId);
+                                       if (baseProfile == null) {
+                                               continue;
+                                       }
+                                       targetProfile = new Profile();
+                                       targetProfile.setId(baseProfile.getId());
+                                       targetProfile.setName(baseProfile.getName());
+                                       targetProfile.setEmulatorNumber(baseProfile.getEmulatorNumber());
+                                       targetProfile.setEnabled(baseProfile.getEnabled());
+                                       targetPersistence.updateEntity(targetProfile);
                                }
+
                                List<DailyTask> existing = iDailyTaskRepository.findByProfileId(targetId);
                                if (existing != null) {
                                        for (DailyTask dt : existing) {
@@ -298,11 +310,8 @@ public class ServScheduler {
                                        }
                                }
                                for (DailyTask src : sourceTasks) {
-                                       DailyTask copy = new DailyTask();
-                                       copy.setProfile(targetProfile);
-                                       copy.setTask(src.getTask());
-                                       copy.setLastExecution(src.getLastExecution());
-                                       copy.setNextSchedule(src.getNextSchedule());
+                                       TpDailyTask taskEntity = targetPersistence.findEntityById(TpDailyTask.class, src.getTask().getId());
+                                       DailyTask copy = new DailyTask(targetProfile, taskEntity, src.getLastExecution(), src.getNextSchedule());
                                        iDailyTaskRepository.addDailyTask(copy);
                                }
                        }

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServScheduler.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServScheduler.java
@@ -235,7 +235,7 @@ public class ServScheduler {
 	 * @param profileId The profile ID
 	 * @param taskEnum The task to remove
 	 */
-	public void removeTaskFromScheduler(Long profileId, TpDailyTaskEnum taskEnum) {
+        public void removeTaskFromScheduler(Long profileId, TpDailyTaskEnum taskEnum) {
 		try {
 			// Get the task queue for the profile
 			TaskQueue queue = queueManager.getQueue(profileId);
@@ -272,10 +272,46 @@ public class ServScheduler {
 		} catch (Exception e) {
 			ServLogs.getServices().appendLog(EnumTpMessageSeverity.ERROR, "Scheduler",
 				"Profile " + profileId, "Error removing task " + taskEnum.getName() + ": " + e.getMessage());
-		}
-	}
+                }
+        }
 
-	public void saveEmulatorPath(String enumConfigurationKey, String filePath) {
+       public boolean copyDailyTasks(Long sourceProfileId, List<Long> targetProfileIds) {
+               try {
+                       if (sourceProfileId == null || targetProfileIds == null || targetProfileIds.isEmpty()) {
+                               return false;
+                       }
+                       List<DailyTask> sourceTasks = iDailyTaskRepository.findByProfileId(sourceProfileId);
+                       if (sourceTasks == null) {
+                               return false;
+                       }
+                       for (Long targetId : targetProfileIds) {
+                               Profile targetProfile = iProfileRepository.getProfileById(targetId);
+                               if (targetProfile == null) {
+                                       continue;
+                               }
+                               List<DailyTask> existing = iDailyTaskRepository.findByProfileId(targetId);
+                               if (existing != null) {
+                                       for (DailyTask dt : existing) {
+                                               iDailyTaskRepository.deleteDailyTask(dt);
+                                       }
+                               }
+                               for (DailyTask src : sourceTasks) {
+                                       DailyTask copy = new DailyTask();
+                                       copy.setProfile(targetProfile);
+                                       copy.setTask(src.getTask());
+                                       copy.setLastExecution(src.getLastExecution());
+                                       copy.setNextSchedule(src.getNextSchedule());
+                                       iDailyTaskRepository.addDailyTask(copy);
+                               }
+                       }
+                       return true;
+               } catch (Exception e) {
+                       ServLogs.getServices().appendLog(EnumTpMessageSeverity.ERROR, "ServScheduler", "-", "Failed to copy tasks: " + e.getMessage());
+                       return false;
+               }
+       }
+
+        public void saveEmulatorPath(String enumConfigurationKey, String filePath) {
 		List<Config> configs = iConfigRepository.getGlobalConfigs();
 
 		Config config = configs.stream().filter(c -> c.getKey().equals(enumConfigurationKey)).findFirst().orElse(null);

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServScheduler.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/impl/ServScheduler.java
@@ -320,11 +320,11 @@ public class ServScheduler {
 			TpConfig tpConfig = iConfigRepository.getTpConfig(TpConfigEnum.GLOBAL_CONFIG);
 			config = new Config();
 			config.setKey(enumConfigurationKey);
-			config.setValor(filePath);
+                    config.setValue(filePath);
 			config.setTpConfig(tpConfig);
 			iConfigRepository.addConfig(config);
 		} else {
-			config.setValor(filePath);
+                    config.setValue(filePath);
 			iConfigRepository.saveConfig(config);
 		}
 	}

--- a/wos-utils/src/test/java/cl/camodev/utiles/ProfileIOTest.java
+++ b/wos-utils/src/test/java/cl/camodev/utiles/ProfileIOTest.java
@@ -29,6 +29,6 @@ class ProfileIOTest {
         assertEquals("test", loadedProfile.getName());
         assertEquals("1", loadedProfile.getEmulatorNumber());
         assertTrue(loadedProfile.getEnabled());
-        assertEquals("value", loadedProfile.getConfigs().get(0).getValor());
+        assertEquals("value", loadedProfile.getConfigs().get(0).getValue());
     }
 }


### PR DESCRIPTION
## Summary
- switch to Hibernate's `HikariCPConnectionProvider`
- support a dedicated SQLite database per profile
- initialize persistence data per profile
- include `hibernate-hikaricp` module so the new provider resolves at runtime
- run SQLite PRAGMAs via JDBC to avoid "Query returns results" warnings
- copy scheduled tasks from one profile to others via new dialog

