### PR TITLE
fix: task-loops bounded

### DIFF
--- a/wos-serv/pom.xml
+++ b/wos-serv/pom.xml
@@ -59,11 +59,23 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 		<!-- Implementación Logback (reemplaza slf4j-log4j12) -->
-		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-classic</artifactId>
-			<scope>runtime</scope>
-		</dependency>
+                <dependency>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-classic</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.mockito</groupId>
+                        <artifactId>mockito-core</artifactId>
+                        <version>5.11.0</version>
+                        <scope>test</scope>
+                </dependency>
 
 
     </dependencies>

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceChestTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceChestTask.java
@@ -12,9 +12,11 @@ import cl.camodev.wosbot.serv.task.DelayedTask;
 
 public class AllianceChestTask extends DelayedTask {
 
-	public AllianceChestTask(DTOProfiles profile, TpDailyTaskEnum tpDailyTask) {
-		super(profile, tpDailyTask);
-	}
+        protected static final int MAX_CLAIM_ATTEMPTS = 5;
+
+        public AllianceChestTask(DTOProfiles profile, TpDailyTaskEnum tpDailyTask) {
+                super(profile, tpDailyTask);
+        }
 
 	@Override
 	protected void execute() {
@@ -65,27 +67,32 @@ public class AllianceChestTask extends DelayedTask {
 		// Search for the claim rewards button
 		DTOImageSearchResult claimAllButtonGifts = emuManager.searchTemplate(EMULATOR_NUMBER,
 		EnumTemplates.ALLIANCE_CHEST_CLAIM_ALL_BUTTON.getTemplate(), 98);
-		if (claimAllButtonGifts.isFound()) {
-			emuManager.tapAtRandomPoint(EMULATOR_NUMBER, claimAllButtonGifts.getPoint(),
-			claimAllButtonGifts.getPoint(),
-			2, 500);
-			sleepTask(500);
-			
-			// Close the window
-			emuManager.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(578, 1180), new DTOPoint(641, 1200), 2, 500);
-		} else {
-			while (true) {
-				DTOImageSearchResult claimButton = emuManager.searchTemplate(EMULATOR_NUMBER,
-				EnumTemplates.ALLIANCE_CHEST_CLAIM_BUTTON.getTemplate(), 90);
-				if (claimButton.isFound()) {
-					emuManager.tapAtRandomPoint(EMULATOR_NUMBER, claimButton.getPoint(), claimButton.getPoint(), 1,
-					500);
-					sleepTask(500);
-				} else {
-					break;
-				}
-			}
-		}
+                if (claimAllButtonGifts.isFound()) {
+                        emuManager.tapAtRandomPoint(EMULATOR_NUMBER, claimAllButtonGifts.getPoint(),
+                        claimAllButtonGifts.getPoint(),
+                        2, 500);
+                        sleepTask(500);
+
+                        // Close the window
+                        emuManager.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(578, 1180), new DTOPoint(641, 1200), 2, 500);
+                } else {
+                        int claimAttempts = 0;
+                        while (claimAttempts < MAX_CLAIM_ATTEMPTS) {
+                                DTOImageSearchResult claimButton = emuManager.searchTemplate(EMULATOR_NUMBER,
+                                EnumTemplates.ALLIANCE_CHEST_CLAIM_BUTTON.getTemplate(), 90);
+                                if (claimButton.isFound()) {
+                                        emuManager.tapAtRandomPoint(EMULATOR_NUMBER, claimButton.getPoint(), claimButton.getPoint(), 1,
+                                        500);
+                                        sleepTask(500);
+                                        claimAttempts++;
+                                } else {
+                                        break;
+                                }
+                        }
+                        if (claimAttempts == MAX_CLAIM_ATTEMPTS) {
+                                logWarning("Maximum alliance gift claim attempts reached");
+                        }
+                }
 		sleepTask(500);
 
 		// Check if honor chest is to be claimed

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/MailRewardsTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/MailRewardsTask.java
@@ -15,7 +15,9 @@ import cl.camodev.wosbot.serv.task.DelayedTask;
 
 public class MailRewardsTask extends DelayedTask {
 
-	private final DTOPoint[] buttons = { new DTOPoint(230, 120), new DTOPoint(360, 120), new DTOPoint(500, 120) };
+        protected static final int MAX_MAIL_SEARCH_ATTEMPTS = 5;
+
+        private final DTOPoint[] buttons = { new DTOPoint(230, 120), new DTOPoint(360, 120), new DTOPoint(500, 120) };
 
 	public MailRewardsTask(DTOProfiles profile, TpDailyTaskEnum tpTask) {
 		super(profile, tpTask);
@@ -45,39 +47,38 @@ public class MailRewardsTask extends DelayedTask {
 						new DTOPoint(450, 1250), 2, 500);
 				sleepTask(500);
 
-				// Check if there are excess unread mail
-				int searchAttempts = 0;
-				while (true) {
-					DTOImageSearchResult unclaimedRewards = emuManager.searchTemplate(EMULATOR_NUMBER,
-							EnumTemplates.MAIL_UNCLAIMED_REWARDS.getTemplate(), 90);
-					if (unclaimedRewards.isFound()) {
-						
-						if(searchAttempts > 0) {
-							logInfo("Excess unread mail found, swiping down and claiming");
-							
-							// Swipe down 10 times
-							for (int i = 0; i < 10; i++) {
-								emuManager.executeSwipe(EMULATOR_NUMBER, new DTOPoint(40, 913), new DTOPoint(40, 400));
-								sleepTask(300);
-							}
-						}
-
-						// Claim rewards
-						emuManager.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(420, 1227),
-								new DTOPoint(450, 1250), 3, 1000);
-						sleepTask(500);
-
-						searchAttempts++;
-					} else {
-						break;
-					}
-					sleepTask(500);
-				}
+                               // Check if there are excess unread mail
+                               int searchAttempts = 0;
+                               while (searchAttempts < MAX_MAIL_SEARCH_ATTEMPTS) {
+                                       DTOImageSearchResult unclaimedRewards = emuManager.searchTemplate(EMULATOR_NUMBER,
+                                                       EnumTemplates.MAIL_UNCLAIMED_REWARDS.getTemplate(), 90);
+                                       if (unclaimedRewards.isFound()) {
+                                               if (searchAttempts > 0) {
+                                                       logInfo("Excess unread mail found, swiping down and claiming");
+                                                       // Swipe down 10 times
+                                                       for (int i = 0; i < 10; i++) {
+                                                               emuManager.executeSwipe(EMULATOR_NUMBER, new DTOPoint(40, 913), new DTOPoint(40, 400));
+                                                               sleepTask(300);
+                                                       }
+                                               }
+                                               // Claim rewards
+                                               emuManager.tapAtRandomPoint(EMULATOR_NUMBER, new DTOPoint(420, 1227),
+                                                               new DTOPoint(450, 1250), 3, 1000);
+                                               sleepTask(500);
+                                               searchAttempts++;
+                                       } else {
+                                               break;
+                                       }
+                                       sleepTask(500);
+                               }
+                               if (searchAttempts == MAX_MAIL_SEARCH_ATTEMPTS) {
+                                       logWarning("Maximum mail claim attempts reached");
+                               }
 			}
 			LocalDateTime nextSchedule = LocalDateTime.now()
 					.plusMinutes(profile.getConfig(EnumConfigurationKey.MAIL_REWARDS_OFFSET_INT, Integer.class));
 			this.reschedule(nextSchedule);
-			ServScheduler.getServices().updateDailyTaskStatus(profile, tpTask, nextSchedule);
+                        servScheduler.updateDailyTaskStatus(profile, tpTask, nextSchedule);
 			emuManager.tapBackButton(EMULATOR_NUMBER);
 
 		} else {

--- a/wos-serv/src/test/java/cl/camodev/wosbot/serv/task/impl/AllianceChestTaskTest.java
+++ b/wos-serv/src/test/java/cl/camodev/wosbot/serv/task/impl/AllianceChestTaskTest.java
@@ -1,0 +1,70 @@
+package cl.camodev.wosbot.serv.task.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+import cl.camodev.wosbot.console.enumerable.EnumConfigurationKey;
+import cl.camodev.wosbot.console.enumerable.EnumTemplates;
+import cl.camodev.wosbot.console.enumerable.TpDailyTaskEnum;
+import cl.camodev.wosbot.emulator.EmulatorManager;
+import cl.camodev.wosbot.ot.DTOImageSearchResult;
+import cl.camodev.wosbot.ot.DTOPoint;
+import cl.camodev.wosbot.ot.DTOProfiles;
+import cl.camodev.wosbot.serv.impl.ServScheduler;
+
+class AllianceChestTaskTest {
+
+    @Test
+    void stopsAfterMaxAttempts() {
+        DTOProfiles profile = new DTOProfiles(1L);
+        profile.setEmulatorNumber("emu");
+        profile.setName("p");
+        profile.setConfig(EnumConfigurationKey.ALLIANCE_CHESTS_OFFSET_INT, 0);
+        profile.setConfig(EnumConfigurationKey.ALLIANCE_HONOR_CHEST_BOOL, false);
+
+        AtomicBoolean warned = new AtomicBoolean(false);
+        EmulatorManager emu = mock(EmulatorManager.class);
+        ServScheduler scheduler = mock(ServScheduler.class);
+        AllianceChestTask task = new TestAllianceChestTask(profile, emu, scheduler, warned);
+
+        DTOImageSearchResult found = new DTOImageSearchResult(true, new DTOPoint(0, 0), 100);
+        DTOImageSearchResult notFound = new DTOImageSearchResult(false, null, 0);
+
+        when(emu.searchTemplate(anyString(), eq(EnumTemplates.ALLIANCE_CHEST_BUTTON.getTemplate()), anyDouble()))
+                .thenReturn(found);
+        when(emu.searchTemplate(anyString(), eq(EnumTemplates.ALLIANCE_CHEST_CLAIM_ALL_BUTTON.getTemplate()), anyDouble()))
+                .thenReturn(notFound);
+        when(emu.searchTemplate(anyString(), eq(EnumTemplates.ALLIANCE_CHEST_CLAIM_BUTTON.getTemplate()), anyDouble()))
+                .thenReturn(found);
+
+        task.execute();
+
+        verify(emu, times(AllianceChestTask.MAX_CLAIM_ATTEMPTS))
+                .searchTemplate(anyString(), eq(EnumTemplates.ALLIANCE_CHEST_CLAIM_BUTTON.getTemplate()), anyDouble());
+        assertTrue(warned.get());
+    }
+
+    private static class TestAllianceChestTask extends AllianceChestTask {
+        private final AtomicBoolean warned;
+
+        TestAllianceChestTask(DTOProfiles profile, EmulatorManager emu, ServScheduler scheduler, AtomicBoolean warned) {
+            super(profile, TpDailyTaskEnum.ALLIANCE_CHESTS);
+            this.emuManager = emu;
+            this.servScheduler = scheduler;
+            this.warned = warned;
+        }
+
+        @Override
+        protected void sleepTask(long millis) {
+        }
+
+        @Override
+        public void logWarning(String message) {
+            warned.set(true);
+        }
+    }
+}

--- a/wos-serv/src/test/java/cl/camodev/wosbot/serv/task/impl/MailRewardsTaskTest.java
+++ b/wos-serv/src/test/java/cl/camodev/wosbot/serv/task/impl/MailRewardsTaskTest.java
@@ -1,0 +1,69 @@
+package cl.camodev.wosbot.serv.task.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+import cl.camodev.wosbot.console.enumerable.EnumConfigurationKey;
+import cl.camodev.wosbot.console.enumerable.EnumTemplates;
+import cl.camodev.wosbot.console.enumerable.TpDailyTaskEnum;
+import cl.camodev.wosbot.emulator.EmulatorManager;
+import cl.camodev.wosbot.ot.DTOImageSearchResult;
+import cl.camodev.wosbot.ot.DTOPoint;
+import cl.camodev.wosbot.ot.DTOProfiles;
+import cl.camodev.wosbot.serv.impl.ServScheduler;
+
+class MailRewardsTaskTest {
+
+    @Test
+    void stopsAfterMaxAttempts() {
+        DTOProfiles profile = new DTOProfiles(1L);
+        profile.setEmulatorNumber("emu");
+        profile.setName("p");
+        profile.setConfig(EnumConfigurationKey.MAIL_REWARDS_OFFSET_INT, 0);
+
+        AtomicBoolean warned = new AtomicBoolean(false);
+        EmulatorManager emu = mock(EmulatorManager.class);
+        ServScheduler scheduler = mock(ServScheduler.class);
+        MailRewardsTask task = new TestMailRewardsTask(profile, emu, scheduler, warned);
+
+        DTOImageSearchResult found = new DTOImageSearchResult(true, new DTOPoint(0, 0), 100);
+        DTOImageSearchResult notFound = new DTOImageSearchResult(false, null, 0);
+
+        when(emu.searchTemplate(anyString(), eq(EnumTemplates.GAME_HOME_FURNACE.getTemplate()), anyDouble()))
+                .thenReturn(found);
+        when(emu.searchTemplate(anyString(), eq(EnumTemplates.GAME_HOME_WORLD.getTemplate()), anyDouble()))
+                .thenReturn(notFound);
+        when(emu.searchTemplate(anyString(), eq(EnumTemplates.MAIL_UNCLAIMED_REWARDS.getTemplate()), anyDouble()))
+                .thenReturn(found);
+
+        task.execute();
+
+        verify(emu, times(MailRewardsTask.MAX_MAIL_SEARCH_ATTEMPTS * 3))
+                .searchTemplate(anyString(), eq(EnumTemplates.MAIL_UNCLAIMED_REWARDS.getTemplate()), anyDouble());
+        assertTrue(warned.get());
+    }
+
+    private static class TestMailRewardsTask extends MailRewardsTask {
+        private final AtomicBoolean warned;
+
+        TestMailRewardsTask(DTOProfiles profile, EmulatorManager emu, ServScheduler scheduler, AtomicBoolean warned) {
+            super(profile, TpDailyTaskEnum.MAIL_REWARDS);
+            this.emuManager = emu;
+            this.servScheduler = scheduler;
+            this.warned = warned;
+        }
+
+        @Override
+        protected void sleepTask(long millis) {
+        }
+
+        @Override
+        public void logWarning(String message) {
+            warned.set(true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- avoid unbounded mail reward scanning by capping attempts and logging a warning
- cap alliance gift claiming attempts to prevent infinite loops
- add unit tests for bounded claim loops
